### PR TITLE
Improving table schema compatibility and testing 

### DIFF
--- a/src/Benchmark/FBBench/FBBench.cs
+++ b/src/Benchmark/FBBench/FBBench.cs
@@ -36,18 +36,18 @@ namespace Benchmark.FBBench
     [CoreJob]
     [RPlotExporter]
     //[ShortRunJob]
+    //[InProcess]
     //[MemoryDiagnoser]
-    [InProcess]
     public class Google_FBBench
     {
-        [Params(3, 30)]
+        [Params(3)]
         public int VectorLength;
 
-        [Params(1, 5)]
+        [Params(5)]
         public int TraversalCount;
 
 #if FLATSHARP
-        [Params(true, false)]
+        [Params(false, true)]
         public bool FlatSharpVectorCache;
 #endif
 
@@ -116,7 +116,7 @@ namespace Benchmark.FBBench
 
 #if FLATSHARP
             {
-                this.fs_serializer = new FlatBufferSerializer(new FlatBufferSerializerOptions { CacheListVectorData = this.FlatSharpVectorCache });
+                this.fs_serializer = new FlatBufferSerializer(new FlatBufferSerializerOptions(cacheListVectorData: this.FlatSharpVectorCache));
                 int offset = this.fs_serializer.Serialize(this.defaultContainer, this.fs_writeMemory);
                 this.fs_readMemory = this.fs_writeMemory.AsSpan(0, offset).ToArray();
                 this.FlatSharp_ParseAndTraverse_SafeMem();

--- a/src/ExperimentalBenchmark/Bench.cs
+++ b/src/ExperimentalBenchmark/Bench.cs
@@ -48,7 +48,7 @@ namespace BenchmarkCore
         private byte[] zf_readBuffer;
         private byte[] fs_writeBuffer = new byte[64 * 1024];
 
-        private FlatBufferSerializer fscacheserializer = new FlatBufferSerializer(new FlatBufferSerializerOptions { CacheListVectorData = true });
+        private FlatBufferSerializer fscacheserializer = new FlatBufferSerializer(new FlatBufferSerializerOptions(cacheListVectorData: true));
         private SpanWriter spanWriter = new UnsafeSpanWriter();
         private InputBuffer fs_readMemory;
         

--- a/src/FlatSharp/FlatBufferSerializer.cs
+++ b/src/FlatSharp/FlatBufferSerializer.cs
@@ -46,14 +46,18 @@ namespace FlatSharp
         /// </summary>
         public FlatBufferSerializer(FlatBufferSerializerOptions options)
         {
-            this.CacheListVectorData = options.CacheListVectorData;
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            this.Options = options;
         }
 
         /// <summary>
-        /// Indicates if list vectors should have their data cached after reading. This option will cause more allocations
-        /// on deserializing, but will improve performance in cases of duplicate accesses to the same indices.
+        /// Gets the set of options used to create this serializer.
         /// </summary>
-        public bool CacheListVectorData { get; }
+        public FlatBufferSerializerOptions Options { get; }
 
         /// <summary>
         /// Compiles and returns the serializer instance for <typeparamref name="T"/>.
@@ -131,7 +135,7 @@ namespace FlatSharp
                 {
                     if (!this.serializerCache.TryGetValue(typeof(TRoot), out serializer))
                     {
-                        serializer = new RoslynSerializerGenerator(this.CacheListVectorData, false).Compile<TRoot>();
+                        serializer = new RoslynSerializerGenerator(this.Options).Compile<TRoot>();
                         this.serializerCache[typeof(TRoot)] = serializer;
                     }
                 }

--- a/src/FlatSharp/FlatBufferSerializerOptions.cs
+++ b/src/FlatSharp/FlatBufferSerializerOptions.cs
@@ -22,9 +22,24 @@
     public class FlatBufferSerializerOptions
     {
         /// <summary>
+        /// Creates a new instance of FlatBufferSerializer options.
+        /// </summary>
+        /// <param name="cacheListVectorData">Indicates that IList vectors should have their reads progressively cached.</param>
+        /// <param name="useCheckedOperations">
+        /// Indicates that FlatSharp should generate unchecked operations. 
+        /// This can result in a nominal performance increase, but most overflows will not be caught. Note that
+        /// this does not affect bounds checking.
+        /// </param>
+        public FlatBufferSerializerOptions(
+            bool cacheListVectorData = false)
+        {
+            this.CacheListVectorData = cacheListVectorData;
+        }
+
+        /// <summary>
         /// Indicates if list vectors should have their data cached after reading. This option will cause more allocations
         /// on deserializing, but will improve performance in cases of duplicate accesses to the same indices.
         /// </summary>
-        public bool CacheListVectorData { get; set; } = false;
+        public bool CacheListVectorData { get; }
     }
 }

--- a/src/FlatSharp/Serialization/SerializationContext.cs
+++ b/src/FlatSharp/Serialization/SerializationContext.cs
@@ -52,9 +52,12 @@ namespace FlatSharp
         /// <summary>
         /// The maximum offset within the buffer.
         /// </summary>
-        internal int Offset
+        public int Offset
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => this.offset;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => this.offset = value;
         }
 

--- a/src/FlatSharpTests/DefaultValueTests.cs
+++ b/src/FlatSharpTests/DefaultValueTests.cs
@@ -36,10 +36,10 @@
             // hand-craft a table here:
             byte[] data =
             {
-                8, 0, 0, 0,   // uoffset to the start of the table.
-                4, 0,         // vtable size
-                4, 0,         // table length
-                4, 0, 0, 0,   // soffset_t to the vtable
+                4, 0, 0, 0,           // uoffset to the start of the table.
+                252, 255, 255, 255,   // soffset_t to the vtable
+                4, 0,                 // vtable size
+                4, 0,                 // table length
             };
 
             var parsed = FlatBufferSerializer.Default.Parse<DefaultValueTable>(data);

--- a/src/FlatSharpTests/NonScalarVectorTests.cs
+++ b/src/FlatSharpTests/NonScalarVectorTests.cs
@@ -107,7 +107,7 @@ namespace FlatSharpTests
 
         private void TestType<T>(bool listCache, Func<T> generator) where T : IEquatable<T>
         {
-            FlatBufferSerializer serializer = new FlatBufferSerializer(new FlatBufferSerializerOptions { CacheListVectorData = listCache });
+            FlatBufferSerializer serializer = new FlatBufferSerializer(new FlatBufferSerializerOptions(cacheListVectorData: listCache));
 
             {
                 var memoryTable = new RootTable<IList<T>>

--- a/src/FlatSharpTests/TableSerializationTests.cs
+++ b/src/FlatSharpTests/TableSerializationTests.cs
@@ -1,145 +1,151 @@
-///*
-// * Copyright 2018 James Courtney
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
+/*
+ * Copyright 2018 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-//namespace FlatSharpTests
-//{
-//    using System;
-//    using System.Buffers.Binary;
-//    using System.Collections.Generic;
-//    using System.Linq;
-//    using System.Text;
-//    using FlatSharp;
-//    using FlatSharp.Attributes;
-//    using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace FlatSharpTests
+{
+    using System;
+    using System.Buffers.Binary;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using FlatSharp;
+    using FlatSharp.Attributes;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-//    [TestClass]
-//    public class TableSerializationTests
-//    {
-//        private static readonly FlatBufferSerializer Serializer = new FlatBufferSerializer(new FlatBufferSerializerOptions { ImplementIDeserializedObject = true });
+    /// <summary>
+    /// Verifies expected binary formats for test data.
+    /// </summary>
+    [TestClass]
+    public class TableSerializationTests
+    {
+        [TestMethod]
+        public void AllMembersNull()
+        {
+            SimpleTable table = new SimpleTable();
 
-//        /// <summary>
-//        /// Serializes a series of linked list nodes and follows the offsets, verifying that the serializer is emitting correct data.
-//        /// </summary>
-//        [TestMethod]
-//        public void TableSerialization_VerifyOffsets()
-//        {
-//            TestLinkedListNode node = new TestLinkedListNode
-//            {
-//                Value = "node 1",
-//                Next = new TestLinkedListNode
-//                {
-//                    Value = "node 2",
-//                    Next = new TestLinkedListNode
-//                    {
-//                        Value = "node 3",
-//                        Next = null
-//                    }
-//                }
-//            };
+            byte[] buffer = new byte[1024];
 
-//            ByteArrayOutputBuffer memory = new ByteArrayOutputBuffer();
-//            ReadOnlySpan<byte> buffer = memory.SizedSpan;
-//            for (int i = 0; i < buffer.Length; ++i)
-//            {
-//                buffer[i] = byte.MaxValue;
-//            }
+            byte[] expectedData =
+            {
+                4, 0, 0, 0,
+                252, 255, 255, 255,
+                4, 0,
+                4, 0,
+            };
 
-//            int offset = Serializer.Serialize(node, memory);
+            int bytesWritten = FlatBufferSerializer.Default.Serialize(table, buffer);
+            Assert.IsTrue(expectedData.AsSpan().SequenceEqual(buffer.AsSpan().Slice(0, bytesWritten)));
+        }
 
-//            var parsedNode = Serializer.Parse<TestLinkedListNode>(memory.SizedSpan.ToArray());
+        [TestMethod]
+        public void RootTableNull()
+        {
+            Assert.ThrowsException<InvalidDataException>(() => FlatBufferSerializer.Default.Serialize<SimpleTable>(null, new byte[1024]));
+        }
 
-//            var node1 = parsedNode;
-//            var node2 = parsedNode.Next;
-//            var node3 = parsedNode.Next.Next;
+        [TestMethod]
+        public void TableWithStruct()
+        {
+            SimpleTable table = new SimpleTable
+            {
+                Struct = new SimpleStruct { Byte = 1, Long = 2, Uint = 3 }
+            };
 
-//            buffer = memory.Memory.Span.Slice(0, offset);
+            byte[] buffer = new byte[1024];
 
-//            IDeserializedObject node1Deserialized = (IDeserializedObject)node1;
-//            IDeserializedObject node2Deserialized = (IDeserializedObject)node2;
-//            IDeserializedObject node3Deserialized = (IDeserializedObject)node3;
+            byte[] expectedData =
+            {
+                4, 0, 0, 0,             // uoffset to table start
+                236, 255, 255, 255,     // soffet to vtable (4 - x = 24 => x = -20)
+                2, 0, 0, 0, 0, 0, 0, 0, // struct.long
+                1,                      // struct.byte
+                0, 0, 0,                // padding
+                3, 0, 0, 0,             // struct.uint
+                8, 0,                   // vtable length
+                20, 0,                  // table length
+                0, 0,                   // index 0 offset
+                4, 0,                   // Index 1 offset
+            };
 
-//            // Make sure the root of the buffer points to the first table.
-//            Assert.AreEqual(BinaryPrimitives.ReadInt32LittleEndian(buffer), node1Deserialized.GetOffset());
+            int bytesWritten = FlatBufferSerializer.Default.Serialize(table, buffer);
+            Assert.IsTrue(expectedData.AsSpan().SequenceEqual(buffer.AsSpan().Slice(0, bytesWritten)));
+        }
 
-//            // First vtable always starts at 4 for FlatSharp
-//            int vtableStart = node1Deserialized.GetOffset() - BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node1Deserialized.GetOffset()));
-//            Assert.AreEqual(4, vtableStart);
+        [TestMethod]
+        public void TableWithStructAndString()
+        {
+            SimpleTable table = new SimpleTable
+            {
+                String = "hi",
+                Struct = new SimpleStruct { Byte = 1, Long = 2, Uint = 3 }
+            };
 
-//            int vtableLength = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(vtableStart));
-//            int tableLength = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(vtableStart + 2));
-//            int valueOffset = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(vtableStart + 4));
-//            int nextNodeOffset = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(vtableStart + 6));
-//            Assert.AreEqual(8, vtableLength); // vt length + table length + string offset + next offset
-//            Assert.AreEqual(12, tableLength); // soffet + uoffset (string) + uoffset (next).
+            byte[] buffer = new byte[1024];
 
-//            // Get the offset to the node 1 string:
-//            int node1StringOffset = node1Deserialized.GetOffset() + valueOffset; // uoffset
-//            node1StringOffset += BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node1StringOffset));
+            byte[] expectedData =
+            {
+                4, 0, 0, 0,             // uoffset to table start
+                228, 255, 255, 255,     // soffet to vtable (4 - x = 24 => x = -20)
+                32, 0, 0, 0,            // uoffset to string
+                0, 0, 0, 0,             // padding
+                2, 0, 0, 0, 0, 0, 0, 0, // struct.long
+                1,                      // struct.byte
+                0, 0, 0,                // padding
+                3, 0, 0, 0,             // struct.uint
+                8, 0,                   // vtable length
+                28, 0,                  // table length
+                4, 0,                   // index 0 offset
+                12, 0,                  // Index 1 offset
+                2, 0, 0, 0,             // string length
+                104, 105, 0,            // hi + null terminator
+            };
 
-//            // Verify the length, then read the items, then check that the null terminator is present and accounted for.
-//            Assert.AreEqual(node1.Value.Length, BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node1StringOffset)));
-//            Assert.AreEqual(node1.Value, Encoding.UTF8.GetString(buffer.Slice(node1StringOffset + 4, 6).ToArray()));
-//            Assert.AreEqual(0, buffer[node1StringOffset + 4 + node1.Value.Length]);
+            int bytesWritten = FlatBufferSerializer.Default.Serialize(table, buffer);
+            Assert.IsTrue(expectedData.AsSpan().SequenceEqual(buffer.AsSpan().Slice(0, bytesWritten)));
+        }
 
-//            // Make sure node 1 points to node 2 correctly.
-//            int node2Offset = node1Deserialized.GetOffset() + nextNodeOffset;
-//            node2Offset += BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node2Offset));
-//            Assert.AreEqual(node2Deserialized.GetOffset(), node2Offset);
+        [FlatBufferTable]
+        public class SimpleTable
+        {
+            [FlatBufferItem(0)]
+            public virtual string String { get; set; }
 
-//            // Make sure that nodes 1 and 2 share a vtable, since they are both fully formed nodes.
-//            Assert.AreEqual(vtableStart, node2Offset - BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node2Offset)));
-//            int node3Offset = node2Deserialized.GetOffset() + nextNodeOffset;
-//            node3Offset += BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node3Offset));
+            [FlatBufferItem(1)]
+            public virtual SimpleStruct Struct { get; set; }
 
-//            Assert.AreEqual(node3Deserialized.GetOffset(), node3Offset);
-//            int node3Vtable = node3Offset - BinaryPrimitives.ReadInt32LittleEndian(buffer.Slice(node3Offset));
-//            Assert.AreNotEqual(vtableStart, node3Vtable);
-//            int node3VtableLength = BinaryPrimitives.ReadInt16LittleEndian(buffer.Slice(node3Vtable));
-//            int node3tableLength = BinaryPrimitives.ReadInt16LittleEndian(buffer.Slice(node3Vtable + 2));
-//            Assert.AreEqual(node3VtableLength, 8);
-//            Assert.AreEqual(node3tableLength, 8);
-//        }
+            [FlatBufferItem(2)]
+            public virtual IList<SimpleStruct> StructVector { get; set; }
 
-//        [FlatBufferTable]
-//        public class SimpleTable
-//        {
-//            [FlatBufferItem(0)]
-//            public virtual string String { get; set; }
+            [FlatBufferItem(4)]
+            public virtual SimpleTable InnerTable { get; set; }
+        }
 
-//            [FlatBufferItem(1)]
-//            public virtual SimpleStruct Struct { get; set; }
+        [FlatBufferStruct]
+        public class SimpleStruct
+        {
+            [FlatBufferItem(0)]
+            public virtual long Long { get; set; }
 
-//            [FlatBufferItem(2)]
-//            public virtual IList<SimpleStruct> StructVector { get; set; }
+            [FlatBufferItem(1)]
+            public virtual byte Byte { get; set; }
 
-//            [FlatBufferItem(4)]
-//            public virtual SimpleTable InnerTable { get; set; }
-//        }
-
-//        [FlatBufferStruct]
-//        public class SimpleStruct
-//        {
-//            [FlatBufferItem(0)]
-//            public double Double { get; set; }
-
-//            [FlatBufferItem(1)]
-//            public byte Byte { get; set; }
-
-//            [FlatBufferItem(2)]
-//            public uint Uint { get; set; }
-//        }
-//    }
-//}
+            [FlatBufferItem(2)]
+            public virtual uint Uint { get; set; }
+        }
+    }
+}

--- a/src/FlatSharpTests/VectorSerializationTests.cs
+++ b/src/FlatSharpTests/VectorSerializationTests.cs
@@ -44,10 +44,10 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                8, 0, 0, 0, // offset to table start
-                4, 0,       // vtable length
-                4, 0,       // table length
-                4, 0, 0, 0  // soffset to vtable
+                4, 0, 0, 0,      // offset to table start
+                252,255,255,255, // soffset to vtable (-4)
+                4, 0,            // vtable length
+                4, 0,            // table length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -67,14 +67,14 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                0, 0, 0, 0,  // vector length
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                0, 0, 0, 0,          // vector length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -94,14 +94,14 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                3, 0, 0, 0,  // vector length,
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
 
                 // vector data
                 1, 0,
@@ -126,14 +126,14 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                0, 0, 0, 0,  // vector length
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                0, 0, 0, 0,          // vector length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -153,15 +153,15 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                3, 0, 0, 0,  // vector length
-                1, 0, 1,     // True false true
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
+                1, 0, 1,             // True false true
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -181,10 +181,10 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                8, 0, 0, 0, // offset to table start
-                4, 0,       // vtable length
-                4, 0,       // table length
-                4, 0, 0, 0  // soffset to vtable
+                4, 0, 0, 0,      // offset to table start
+                252,255,255,255, // soffset to vtable (-4)
+                4, 0,            // vtable length
+                4, 0,            // table length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -204,15 +204,15 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                0, 0, 0, 0,  // vector length
-                0,           // null terminator (special case for string vectors).
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to string
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                0, 0, 0, 0,          // vector length
+                0,                   // null terminator (special case for strings).
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -232,15 +232,15 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                3, 0, 0, 0,  // vector length
-                1, 2, 3, 0,  // data + null terminator (special case for string vectors).
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
+                1, 2, 3, 0,          // data + null terminator (special case for string vectors).
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -260,14 +260,14 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                3, 0, 0, 0,  // vector length
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
 
                 // vector data
                 1, 0, 0, 0, 0, 0, 0, 0,
@@ -292,10 +292,10 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                8, 0, 0, 0, // offset to table start
-                4, 0,       // vtable length
-                4, 0,       // table length
-                4, 0, 0, 0  // soffset to vtable
+                4, 0, 0, 0,      // offset to table start
+                252,255,255,255, // soffset to vtable (-4)
+                4, 0,            // vtable length
+                4, 0,            // table length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));
@@ -315,14 +315,14 @@ namespace FlatSharpTests
 
             byte[] expectedResult =
             {
-                12, 0, 0, 0, // offset to table start
-                6, 0,        // vtable length
-                8, 0,        // table length
-                4, 0,        // offset of index 0 field
-                0, 0,        // padding to 4-byte alignment
-                8, 0, 0, 0,  // soffset to vtable
-                4, 0, 0, 0,  // uoffset_t to vector
-                0, 0, 0, 0,  // vector length
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                0, 0, 0, 0,          // vector length
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));


### PR DESCRIPTION
1) Optimize VTableBuilder.EndObject
2) Make FlatBufferSerializerOptions immutable
3) Rework table serialization to correctly align interior items
4) Update unit tests to reflect the above.

Progress towards fixing #8. More tests still needed.