### PR TITLE
Updates to default values [breaking change]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /src/FlatSharpTests/coverage.netcoreapp2.1.xml
 /src/FlatSharpTests/coverage.net47.xml
 /src/FlatSharpTests/coverage
+/src/FlatSharpTests/.coverage

--- a/README.md
+++ b/README.md
@@ -36,12 +36,10 @@ public class MonsterTable
     [FlatBufferItem(0)]
     public virtual Position Position { get; set; }
     
-    [FlatBufferItem(1)]
-    [DefaultValue((short)150)]
+    [FlatBufferItem(1, DefaultValue = (short)150)]
     public virtual short Mana { get; set; }
     
-    [FlatBufferItem(2)]
-    [DefaultValue((short)100)]
+    [FlatBufferItem(2, DefaultValue = (short)100)]
     public virtual short HP { get; set; }
     
     [FlatBufferItem(3)]
@@ -59,8 +57,7 @@ public class MonsterTable
     // Note that that the next index starts at 8. Unions are 'double-wide' types, so the previous
     // element occupies indices 6 and 7!
     
-    [FlatBufferItem(8)]
-    [DefaultValue((int)Color.Blue)]
+    [FlatBufferItem(8, DefaultValue = (int)Color.Blue)]
     public virtual int RawColor { get; set; }
     
     // Expressing enums still possible.

--- a/src/Benchmark/FBBench/FBBench.cs
+++ b/src/Benchmark/FBBench/FBBench.cs
@@ -40,7 +40,7 @@ namespace Benchmark.FBBench
     //[MemoryDiagnoser]
     public class Google_FBBench
     {
-        [Params(3)]
+        [Params(3, 30)]
         public int VectorLength;
 
         [Params(1, 5)]

--- a/src/FlatSharp/Attributes/FlatBufferItemAttribute.cs
+++ b/src/FlatSharp/Attributes/FlatBufferItemAttribute.cs
@@ -42,5 +42,11 @@ namespace FlatSharp.Attributes
         /// For tables, indicates if this field is deprecated. Deprecated fields are not written or read.
         /// </summary>
         public bool Deprecated { get; set; }
+
+        /// <summary>
+        /// For table items, gets or sets the default value. The type of the object must match the
+        /// type of the property.
+        /// </summary>
+        public object DefaultValue { get; set; }
     }
 }

--- a/src/FlatSharp/FlatSharp.csproj
+++ b/src/FlatSharp/FlatSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>FlatSharp</AssemblyName>
     <RootNamespace>FlatSharp</RootNamespace>

--- a/src/FlatSharp/ReflectedMethods.cs
+++ b/src/FlatSharp/ReflectedMethods.cs
@@ -66,17 +66,9 @@ namespace FlatSharp
 
         public static MethodInfo SerializationHelpers_EnsureNonNull(Type t) => GetMethod(typeof(SerializationHelpers), nameof(SerializationHelpers.EnsureNonNull)).MakeGenericMethod(t);
 
-        private static MethodInfo GetMethod(Type type, string methodName, Type[] parameterTypes = null)
+        private static MethodInfo GetMethod(Type type, string methodName)
         {
-            MethodInfo methodInfo;
-            if (parameterTypes == null)
-            {
-                methodInfo = type.GetMethod(methodName, AllFlags);
-            }
-            else
-            {
-                methodInfo = type.GetMethod(methodName, AllFlags, null, parameterTypes, null);
-            }
+            MethodInfo methodInfo = type.GetMethod(methodName, AllFlags);
 
             if (methodInfo == null)
             {

--- a/src/FlatSharp/Serialization/CSharpHelpers.cs
+++ b/src/FlatSharp/Serialization/CSharpHelpers.cs
@@ -72,34 +72,66 @@ namespace FlatSharp
         internal static string GetDefaultValueToken(TableMemberModel memberModel)
         {
             var itemTypeModel = memberModel.ItemTypeModel;
+            var clrType = itemTypeModel.ClrType;
 
             string defaultValue = $"default({GetCompilableTypeName(memberModel.ItemTypeModel.ClrType)})";
             if (memberModel.HasDefaultValue)
             {
                 string literalSpecifier = string.Empty;
+                string cast = string.Empty;
+                string defaultValueLiteral = memberModel.DefaultValue.ToString();
 
-                if (itemTypeModel.ClrType == typeof(float))
+                if (clrType == typeof(bool))
+                {
+                    // Bool.ToString() returns 'True', which is not the right keyword.
+                    defaultValueLiteral = defaultValueLiteral.ToLower();
+                }
+                else if (clrType == typeof(sbyte))
+                {
+                    cast = "(sbyte)";
+                }
+                else if (clrType == typeof(byte))
+                {
+                    cast = "(byte)";
+                }
+                else if (clrType == typeof(short))
+                {
+                    cast = "(short)";
+                }
+                else if (clrType == typeof(ushort))
+                {
+                    cast = "(ushort)";
+                }
+                else if (clrType == typeof(float))
                 {
                     literalSpecifier = "f";
                 }
-                else if (itemTypeModel.ClrType == typeof(uint))
+                else if (clrType == typeof(uint))
                 {
-                    literalSpecifier = "U";
+                    literalSpecifier = "u";
                 }
-                else if (itemTypeModel.ClrType == typeof(double))
+                else if (clrType == typeof(int))
+                {
+                    cast = "(int)";
+                }
+                else if (clrType == typeof(double))
                 {
                     literalSpecifier = "d";
                 }
-                else if (itemTypeModel.ClrType == typeof(long))
+                else if (clrType == typeof(long))
                 {
                     literalSpecifier = "L";
                 }
-                else if (itemTypeModel.ClrType == typeof(ulong))
+                else if (clrType == typeof(ulong))
                 {
-                    literalSpecifier = "UL";
+                    literalSpecifier = "ul";
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unexpected default value type: " + clrType.FullName);
                 }
 
-                defaultValue = $"{memberModel.DefaultValue}{literalSpecifier}";
+                defaultValue = $"{cast}{defaultValueLiteral}{literalSpecifier}";
             }
 
             return defaultValue;

--- a/src/FlatSharp/Serialization/CSharpHelpers.cs
+++ b/src/FlatSharp/Serialization/CSharpHelpers.cs
@@ -112,6 +112,7 @@ namespace FlatSharp
                 }
                 else if (clrType == typeof(int))
                 {
+                    // shouldn't need this one, but let's be thorough.
                     cast = "(int)";
                 }
                 else if (clrType == typeof(double))

--- a/src/FlatSharp/TypeModel/StructTypeModel.cs
+++ b/src/FlatSharp/TypeModel/StructTypeModel.cs
@@ -18,6 +18,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
     using System.Reflection;
     using FlatSharp.Attributes;
@@ -104,6 +105,11 @@
                 if (index != expectedIndex)
                 {
                     throw new InvalidFlatBufferDefinitionException($"FlatBuffer struct {this.ClrType.Name} does not declare an item with index {expectedIndex}. Structs must have sequenential indexes starting at 0.");
+                }
+
+                if (!object.ReferenceEquals(propertyAttribute.DefaultValue, null))
+                {
+                    throw new InvalidFlatBufferDefinitionException($"FlatBuffer struct {this.ClrType.Name} declares default value on {expectedIndex}. Structs may not have default values.");
                 }
 
                 expectedIndex++;

--- a/src/FlatSharp/TypeModel/TableTypeModel.cs
+++ b/src/FlatSharp/TypeModel/TableTypeModel.cs
@@ -104,7 +104,6 @@
                 {
                     Property = x,
                     Attribute = x.GetCustomAttribute<FlatBufferItemAttribute>(),
-                    DefaultValue = x.GetCustomAttribute<DefaultValueAttribute>(),
                 })
                 .Where(x => x.Attribute != null)
                 .Where(x => !x.Attribute.Deprecated)
@@ -112,7 +111,6 @@
                 {
                     x.Property,
                     x.Attribute,
-                    x.DefaultValue,
                     ItemTypeModel = RuntimeTypeModel.CreateFrom(x.Property.PropertyType),
                 })
                 .ToList();
@@ -123,10 +121,10 @@
                 bool hasDefaultValue = false;
                 object defaultValue = null;
 
-                if (property.DefaultValue != null)
+                if (!object.ReferenceEquals(property.Attribute.DefaultValue, null))
                 {
                     hasDefaultValue = true;
-                    defaultValue = property.DefaultValue.Value;
+                    defaultValue = property.Attribute.DefaultValue;
                 }
                 
                 ushort index = property.Attribute.Index;

--- a/src/FlatSharpTests/ClassLib/TypeModelTests.cs
+++ b/src/FlatSharpTests/ClassLib/TypeModelTests.cs
@@ -125,6 +125,13 @@ namespace FlatSharpTests
         }
 
         [TestMethod]
+        public void TypeModel_Struct_DefaultValue()
+        {
+            Assert.ThrowsException<InvalidFlatBufferDefinitionException>(() =>
+                RuntimeTypeModel.CreateFrom(typeof(StructWithDefaultValue)));
+        }
+
+        [TestMethod]
         public void TypeModel_Vector_VectorNotAllowed()
         {
             Assert.ThrowsException<InvalidFlatBufferDefinitionException>(() =>
@@ -358,6 +365,13 @@ namespace FlatSharpTests
         {
             [FlatBufferItem(0)]
             public abstract T Value { get; set; }
+        }
+
+        [FlatBufferStruct]
+        public class StructWithDefaultValue
+        {
+            [FlatBufferItem(0, DefaultValue = 100)]
+            public virtual int Int { get; set; }
         }
 
         [FlatBufferStruct]

--- a/src/FlatSharpTests/FlatSharpTests.csproj
+++ b/src/FlatSharpTests/FlatSharpTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="ReportGenerator" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlatSharpTests/OracleTests/OracleSerializeTests.cs
+++ b/src/FlatSharpTests/OracleTests/OracleSerializeTests.cs
@@ -17,6 +17,7 @@
  namespace FlatSharpTests
 {
     using FlatSharp;
+    using FlatSharp.Unsafe;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Runtime.InteropServices;
@@ -29,7 +30,18 @@
     public partial class OracleSerializeTests
     {
         [TestMethod]
-        public void SimpleTypes()
+        public void SimpleTypes_SafeSpanWriter()
+        {
+            this.SimpleTypesTest(new SpanWriter());
+        }
+
+        [TestMethod]
+        public void SimpleTypes_UnsafeSpanWriter()
+        {
+            this.SimpleTypesTest(new UnsafeSpanWriter());
+        }
+
+        private void SimpleTypesTest(SpanWriter writer)
         {
             var simple = new BasicTypes
             {
@@ -48,7 +60,7 @@
             };
 
             Span<byte> memory = new byte[10240];
-            int size = FlatBufferSerializer.Default.Serialize(simple, memory);
+            int size = FlatBufferSerializer.Default.Serialize(simple, memory, writer);
 
             var oracle = Oracle.BasicTypes.GetRootAsBasicTypes(
                 new FlatBuffers.ByteBuffer(memory.Slice(0, size).ToArray()));

--- a/src/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -498,8 +498,7 @@ namespace FlatSharpTests
         [FlatBufferTable]
         public class RootTable2<TVector>
         {
-            [FlatBufferItem(0)]
-            [DefaultValue((byte)201)]
+            [FlatBufferItem(0, DefaultValue = (byte)201)]
             public virtual byte AlignmentImp { get; set; }
 
             [FlatBufferItem(1)]

--- a/src/FlatSharpTests/testsWithCoverage.cmd
+++ b/src/FlatSharpTests/testsWithCoverage.cmd
@@ -1,1 +1,2 @@
 dotnet test /p:AltCover=true /p:AltCoverAttributeFilter=ExcludeFromCodeCoverage
+dotnet %UserProfile%\.nuget\packages\reportgenerator\4.1.2\tools\netcoreapp2.1\ReportGenerator.dll -reports:coverage.netcoreapp2.1.xml -targetdir:.coverage\


### PR DESCRIPTION
[DefaultValue] attribute in .NET does not expose .ctors for all types, which makes it difficult to use.