### PR TITLE
Add generated files to Compile

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
+++ b/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
@@ -13,5 +13,9 @@
 
     <Message Text="$(CompilerInvocation) %(FlatSharpSchema.fullpath)" Importance="high" />
     <Exec Command="$(CompilerInvocation) %(FlatSharpSchema.fullpath)" CustomErrorRegularExpression=".*" Condition=" '%(FlatSharpSchema.fullpath)' != '' " />
+    
+    <ItemGroup>
+      <Compile Include="%(FlatSharpSchema.fullpath).generated.cs" Condition="Exists('%(FlatSharpSchema.fullpath).generated.cs')" />
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
When rebuilding from scratch, the compilation will fail because the generated files are not added for compile.
Fix for #45 

I am no MSBuild specialist, so I might be missing something, but this works perfectly for me.
It is assuming the suffix for the generation to be ".generated.cs" though, which is dependent on the compiler.
A better way could be for the compiler to output the path of the generated files, and use that instead.

This is what Microsoft Orleans does for its build-time code generation, for instance.