### PR TITLE
Move auto built fbs output to intermediate output dir

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
+++ b/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
@@ -12,6 +12,11 @@
     </PropertyGroup>
 
     <Message Text="$(CompilerInvocation) %(FlatSharpSchema.fullpath)" Importance="high" />
-    <Exec Command="$(CompilerInvocation) %(FlatSharpSchema.fullpath)" CustomErrorRegularExpression=".*" Condition=" '%(FlatSharpSchema.fullpath)' != '' " />
+    <Exec Command="$(CompilerInvocation) %(FlatSharpSchema.fullpath) $(IntermediateOutputPath)" CustomErrorRegularExpression=".*" Condition=" '%(FlatSharpSchema.fullpath)' != '' " />
+    <ItemGroup>
+      <GeneratedFbs Include="$(IntermediateOutputPath)*.generated.cs" />
+      <Compile Include="@(GeneratedFbs)" />
+      <FileWrites Include="@(GeneratedFbs)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
+++ b/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
-  <Target Name="FlatSharpFbsCompile" BeforeTargets="BeforeBuild">
+  <Target Name="FlatSharpFbsCompile" BeforeTargets="ResolveAssemblyReferences">
     <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
       <CompilerPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\tools\netcoreapp2.1\FlatSharp.Compiler.dll'))</CompilerPath>
       <CompilerInvocation>dotnet $(CompilerPath)</CompilerInvocation>

--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -39,8 +39,11 @@ namespace FlatSharp.Compiler
                     context.PushScope("$");
 
                     // Read existing file to see if we even need to do any work.
-                    string outputFileName = args[0] + ".generated.cs";
-                    string fbsText = File.ReadAllText(args[0]);
+                    string fbsFileName = Path.GetFileName(args[0]);
+                    string outputFileName = fbsFileName + ".generated.cs";
+                    string outputPath = args.Length < 2 || string.IsNullOrEmpty(args[1]) ? Path.GetDirectoryName(args[0]) : args[1];
+                    string outputFullPath = Path.Combine(outputPath, outputFileName);
+                    // string fbsText = File.ReadAllText(args[0]);
 
                     int attemptCount = 0;
                     while (attemptCount++ <= 5)
@@ -49,9 +52,9 @@ namespace FlatSharp.Compiler
                         {
                             RootNodeDefinition rootNode = ParseSyntax(args[0], new IncludeFileLoader());
 
-                            if (File.Exists(outputFileName))
+                            if (File.Exists(outputFullPath))
                             {
-                                string existingOutput = File.ReadAllText(outputFileName);
+                                string existingOutput = File.ReadAllText(outputFullPath);
                                 if (existingOutput.Contains(rootNode.InputHash))
                                 {
                                     // Input file unchanged.
@@ -60,7 +63,7 @@ namespace FlatSharp.Compiler
                             }
 
                             string cSharp = CreateCSharp(rootNode);
-                            File.WriteAllText(outputFileName, cSharp);
+                            File.WriteAllText(outputFullPath, cSharp);
                         }
                         catch (IOException)
                         {


### PR DESCRIPTION
Following convention used in a lot of tools (including protobuf), codegen output should go to the intermediate output dir (defaults to obj). This prevents cluttering the source tree and plays nicely with existing gitignores etc.
I have added an optional extra arg to the compiler to allow us to specify the output dir, the default is the current behaviour of putting the output next to the fbs.
This PR also includes a change to `BeforeTargets` to fix solution checking in Rider and Resharper.