### PR TITLE
Remove Memory support for everything but byte.

### DIFF
--- a/src/FlatSharp.Runtime/IO/InputBuffer.cs
+++ b/src/FlatSharp.Runtime/IO/InputBuffer.cs
@@ -146,31 +146,23 @@ namespace FlatSharp
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Memory<byte> ReadByteMemoryBlock(
-           int uoffset,
-           int sizePerItem)
+        public Memory<byte> ReadByteMemoryBlock(int uoffset)
         {
             return this.ReadByteMemoryBlockImpl(
                 uoffset,
-                sizePerItem,
                 this.GetByteMemory);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyMemory<byte> ReadByteReadOnlyMemoryBlock(
-           int uoffset,
-           int sizePerItem)
+        public ReadOnlyMemory<byte> ReadByteReadOnlyMemoryBlock(int uoffset)
         {
             return this.ReadByteMemoryBlockImpl(
                 uoffset,
-                sizePerItem,
                 this.GetReadOnlyByteMemory);
         }
 
-        private T ReadByteMemoryBlockImpl<T>(int uoffset, int sizePerItem, Func<int, int, T> callback)
+        private T ReadByteMemoryBlockImpl<T>(int uoffset, Func<int, int, T> callback)
         {
-            Debug.Assert(sizePerItem == 1);
-
             checked
             {
                 // The local value stores a uoffset_t, so follow that now.
@@ -180,42 +172,6 @@ namespace FlatSharp
                 return callback(
                     uoffset + sizeof(uint),
                     (int)this.ReadUInt(uoffset));
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Memory<T> ReadMemoryBlock<T>(
-           int uoffset,
-           int sizePerItem) where T : struct
-        {
-            return this.ReadMemoryBlockImpl<T>(uoffset, sizePerItem, (s, l) => this.GetByteMemory(s, l));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyMemory<T> ReadReadOnlyMemoryBlock<T>(
-           int uoffset,
-           int sizePerItem) where T : struct
-        {
-            return this.ReadMemoryBlockImpl<T>(uoffset, sizePerItem, this.GetReadOnlyByteMemory);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Memory<T> ReadMemoryBlockImpl<T>(
-           int uoffset,
-           int sizePerItem,
-           Func<int, int, ReadOnlyMemory<byte>> callback) where T : struct
-        {
-            checked
-            {
-                // The local value stores a uoffset_t, so follow that now.
-                uoffset = uoffset + this.ReadUOffset(uoffset);
-
-                ReadOnlyMemory<byte> innerMemory = callback(
-                    uoffset + sizeof(uint),
-                    ((int)this.ReadUInt(uoffset)) * sizePerItem);
-
-                MemoryTypeChanger<T> typeChanger = new MemoryTypeChanger<T>(MemoryMarshal.AsMemory(innerMemory));
-                return typeChanger.Memory;
             }
         }
 

--- a/src/FlatSharp/Serialization/ParserCodeGenerator.cs
+++ b/src/FlatSharp/Serialization/ParserCodeGenerator.cs
@@ -304,27 +304,13 @@ $@"
 
         private void ImplementMemoryVectorReadMethod(VectorTypeModel typeModel)
         {
-            string invocation;
-            if (typeModel.ItemTypeModel.ClrType == typeof(byte))
+            string invocation = nameof(InputBuffer.ReadByteMemoryBlock);
+            if (typeModel.IsReadOnly)
             {
-                invocation = nameof(InputBuffer.ReadByteMemoryBlock);
-                if (typeModel.IsReadOnly)
-                {
-                    invocation = nameof(InputBuffer.ReadByteReadOnlyMemoryBlock);
-                }
-            }
-            else
-            {
-                string methodName = nameof(InputBuffer.ReadMemoryBlock);
-                if (typeModel.IsReadOnly)
-                {
-                    methodName = nameof(InputBuffer.ReadReadOnlyMemoryBlock);
-                }
-
-                invocation =  $"{methodName}<{CSharpHelpers.GetCompilableTypeName(typeModel.ItemTypeModel.ClrType)}>";
+                invocation = nameof(InputBuffer.ReadByteReadOnlyMemoryBlock);
             }
 
-            string body = $"memory.{invocation}(offset, {typeModel.ItemTypeModel.InlineSize})";
+            string body = $"memory.{invocation}(offset)";
 
             // Greedy deserialize has the invariant that we no longer touch the
             // original buffer. This means a memory copy here.
@@ -361,10 +347,10 @@ $@"
             var itemTypeModel = typeModel.ItemTypeModel;
 
             string statement;
-            if (itemTypeModel is ScalarTypeModel scalarModel && scalarModel.NativelyReadableFromMemory)
+            if (itemTypeModel is ScalarTypeModel scalarModel && scalarModel.ClrType == typeof(byte))
             {
                 // Memory is faster in situations where we can get away with it.
-                statement = $"memory.{nameof(InputBuffer.ReadMemoryBlock)}<{CSharpHelpers.GetCompilableTypeName(itemTypeModel.ClrType)}>(offset, {itemTypeModel.InlineSize}).ToArray()";
+                statement = $"memory.{nameof(InputBuffer.ReadByteMemoryBlock)}(offset).ToArray()";
             }
             else
             {

--- a/src/FlatSharp/TypeModel/VectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/VectorTypeModel.cs
@@ -184,17 +184,13 @@ namespace FlatSharp.TypeModel
 
             if (this.isMemory)
             {
-                if (this.memberTypeModel.SchemaType != FlatBufferSchemaType.Scalar)
+                if (this.memberTypeModel is ScalarTypeModel scalarModel && scalarModel.ClrType == typeof(byte))
                 {
-                    throw new InvalidFlatBufferDefinitionException("Vectors may only be Memory<T> or ReadOnlyMemory<T> when the type is a scalar.");
+                    // allowed
                 }
-
-                // We can play some tricks on little-endian machines that allow us to store other types inside our vectors.
-                // 1 byte types (bool, byte, sbyte) are always allowed. However, anything larger is subject to endianness issues.
-                ScalarTypeModel scalarModel = (ScalarTypeModel)this.memberTypeModel;
-                if (!scalarModel.NativelyReadableFromMemory)
+                else
                 {
-                    throw new InvalidFlatBufferDefinitionException("Memory<T> vectors may only use 1-byte sized elements on big-endian architectures. Consider using IList<T> instead.");
+                    throw new InvalidFlatBufferDefinitionException("Vectors may only be Memory<T> or ReadOnlyMemory<T> when the type is an unsigned byte.");
                 }
             }
         }

--- a/src/FlatSharpTests/ClassLib/InputBufferTests.cs
+++ b/src/FlatSharpTests/ClassLib/InputBufferTests.cs
@@ -168,8 +168,7 @@ namespace FlatSharpTests
 
             byte[] expected = new byte[] { 1, 2, 3, 4, 5, 6, 7, };
 
-            Assert.IsTrue(inputBuffer.ReadReadOnlyMemoryBlock<byte>(0, 1).Span.SequenceEqual(expected));
-            Assert.IsTrue(inputBuffer.ReadByteReadOnlyMemoryBlock(0, 1).Span.SequenceEqual(expected));
+            Assert.IsTrue(inputBuffer.ReadByteReadOnlyMemoryBlock(0).Span.SequenceEqual(expected));
         }
 
         private void TestDeserialize<TBuffer, TType>(Func<byte[], TBuffer> bufferBuilder) 
@@ -178,7 +177,6 @@ namespace FlatSharpTests
         {
             TType table = new TType
             {
-                IntMemory = new int[] { 1, 2, 3, 4, 5, },
                 Memory = new byte[] { 6, 7, 8, 9, 10 }
             };
 
@@ -189,15 +187,12 @@ namespace FlatSharpTests
             var parsed = FlatBufferSerializer.Default.Parse<TType>(buffer);
             for (int i = 1; i <= 5; ++i)
             {
-                Assert.AreEqual(i, parsed.IntMemory.Span[i - 1]);
                 Assert.AreEqual(i + 5, parsed.Memory.Span[i - 1]);
             }
         }
 
         private interface IMemoryTable
         {
-            ReadOnlyMemory<int> IntMemory { get; set; }
-
             ReadOnlyMemory<byte> Memory { get; set; }
         }
 
@@ -205,9 +200,6 @@ namespace FlatSharpTests
         public class ReadOnlyMemoryTable : IMemoryTable
         {
             [FlatBufferItem(0)]
-            public virtual ReadOnlyMemory<int> IntMemory { get; set; }
-
-            [FlatBufferItem(1)]
             public virtual ReadOnlyMemory<byte> Memory { get; set; }
         }
 
@@ -215,12 +207,7 @@ namespace FlatSharpTests
         public class MemoryTable : IMemoryTable
         {
             [FlatBufferItem(0)]
-            public virtual Memory<int> IntMemory { get; set; }
-
-            [FlatBufferItem(1)]
             public virtual Memory<byte> Memory { get; set; }
-
-            ReadOnlyMemory<int> IMemoryTable.IntMemory { get => this.IntMemory; set => this.IntMemory = MemoryMarshal.AsMemory(value); }
 
             ReadOnlyMemory<byte> IMemoryTable.Memory { get => this.Memory; set => this.Memory = MemoryMarshal.AsMemory(value); }
         }

--- a/src/FlatSharpTests/ClassLib/TypeModelTests.cs
+++ b/src/FlatSharpTests/ClassLib/TypeModelTests.cs
@@ -230,30 +230,49 @@ namespace FlatSharpTests
         }
 
         [TestMethod]
-        public void TypeModel_Vector_MemoryOfScalar()
+        public void TypeModel_Vector_MemoryOfByte()
         {
-            var model = this.VectorTest(typeof(Memory<>), typeof(int));
+            var model = this.VectorTest(typeof(Memory<>), typeof(byte));
             Assert.IsFalse(model.IsList);
             Assert.IsTrue(model.IsMemoryVector);
             Assert.IsFalse(model.IsReadOnly);
         }
 
         [TestMethod]
-        public void TypeModel_Vector_MemoryOfEnum()
+        public void TypeModel_Vector_MemoryOfScalar_NotAllowed()
         {
-            var model = this.VectorTest(typeof(Memory<>), typeof(TaggedEnum));
-            Assert.IsFalse(model.IsList);
-            Assert.IsTrue(model.IsMemoryVector);
-            Assert.IsFalse(model.IsReadOnly);
+            Assert.ThrowsException<InvalidFlatBufferDefinitionException>(
+                () => RuntimeTypeModel.CreateFrom(typeof(Memory<int>)));
         }
 
         [TestMethod]
-        public void TypeModel_Vector_ReadOnlyMemoryOfScalar()
+        public void TypeModel_Vector_MemoryOfEnum_NotAllowed()
         {
-            var model = this.VectorTest(typeof(ReadOnlyMemory<>), typeof(double));
+            Assert.ThrowsException<InvalidFlatBufferDefinitionException>(
+                () => RuntimeTypeModel.CreateFrom(typeof(Memory<TaggedEnum>)));
+        }
+
+        [TestMethod]
+        public void TypeModel_Vector_ReadOnlyMemoryOfByte()
+        {
+            var model = this.VectorTest(typeof(ReadOnlyMemory<>), typeof(byte));
             Assert.IsFalse(model.IsList);
             Assert.IsTrue(model.IsMemoryVector);
             Assert.IsTrue(model.IsReadOnly);
+        }
+
+        [TestMethod]
+        public void TypeModel_Vector_ReadOnlyMemoryOfScalar_NotAllowed()
+        {
+            Assert.ThrowsException<InvalidFlatBufferDefinitionException>(
+                () => RuntimeTypeModel.CreateFrom(typeof(ReadOnlyMemory<int>)));
+        }
+
+        [TestMethod]
+        public void TypeModel_Vector_ReadOnlyMemoryOfEnum_NotAllowed()
+        {
+            Assert.ThrowsException<InvalidFlatBufferDefinitionException>(
+                () => RuntimeTypeModel.CreateFrom(typeof(ReadOnlyMemory<TaggedEnum>)));
         }
 
         [TestMethod]

--- a/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
@@ -118,7 +118,7 @@ namespace FlatSharpTests.Compiler
             this.RunSingleTest<T[]>($"[{fbsType}]  (vectortype: Array)");
             this.RunSingleTest<IReadOnlyList<T>>($"[{fbsType}]  (vectortype: IReadOnlyList)");
 
-            if (typeof(T).IsValueType)
+            if (typeof(T) == typeof(byte))
             {
                 this.RunSingleTest<Memory<T>>($"[{fbsType}]  (vectortype: Memory)");
                 this.RunSingleTest<ReadOnlyMemory<T>>($"[{fbsType}]  (vectortype: ReadOnlyMemory)");

--- a/src/FlatSharpTests/SerializationTests/ScalarVectorTests.cs
+++ b/src/FlatSharpTests/SerializationTests/ScalarVectorTests.cs
@@ -142,6 +142,7 @@ namespace FlatSharpTests
 
         private void TestType<T>(Func<T> generator, int length)
         {
+            if (typeof(T) == typeof(byte))
             {
                 var memoryTable = new RootTable<Memory<T>>
                 {
@@ -163,6 +164,7 @@ namespace FlatSharpTests
                 }
             }
 
+            if (typeof(T) == typeof(byte))
             {
                 var memoryTable = new RootTable<ReadOnlyMemory<T>>
                 {

--- a/src/FlatSharpTests/SerializationTests/VectorDeserializationTests.cs
+++ b/src/FlatSharpTests/SerializationTests/VectorDeserializationTests.cs
@@ -107,7 +107,7 @@ namespace FlatSharpTests
                 0, 0, 0, 0,  // vector length
             };
             
-            var item = FlatBufferSerializer.Default.Parse<RootTable<Memory<bool>>>(data);
+            var item = FlatBufferSerializer.Default.Parse<RootTable<Memory<byte>>>(data);
             Assert.IsTrue(item.Vector.IsEmpty);
         }
 
@@ -124,14 +124,14 @@ namespace FlatSharpTests
                 8, 0, 0, 0,  // soffset to vtable
                 4, 0, 0, 0,  // uoffset_t to vector
                 3, 0, 0, 0,  // vector length
-                1, 0, 1,     // True false true
+                1, 2, 3,     // True false true
             };
 
-            var item = FlatBufferSerializer.Default.Parse<RootTable<Memory<bool>>>(data);
+            var item = FlatBufferSerializer.Default.Parse<RootTable<Memory<byte>>>(data);
             Assert.AreEqual(3, item.Vector.Length);
-            Assert.IsTrue(item.Vector.Span[0]);
-            Assert.IsFalse(item.Vector.Span[1]);
-            Assert.IsTrue(item.Vector.Span[2]);
+            Assert.AreEqual((byte)1, item.Vector.Span[0]);
+            Assert.AreEqual((byte)2, item.Vector.Span[1]);
+            Assert.AreEqual((byte)3, item.Vector.Span[2]);
         }
 
         [TestMethod]

--- a/src/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -117,7 +117,7 @@ namespace FlatSharpTests
         [TestMethod]
         public void EmptyMemoryVector()
         {
-            var root = new RootTable<Memory<bool>>
+            var root = new RootTable<Memory<byte>>
             {
                 Vector = default,
             };
@@ -144,9 +144,9 @@ namespace FlatSharpTests
         [TestMethod]
         public void SimpleMemoryVector()
         {
-            var root = new RootTable<Memory<bool>>
+            var root = new RootTable<Memory<byte>>
             {
-                Vector = new bool[] { true, false, true },
+                Vector = new byte[] { 1, 2, 3 },
             };
 
             Span<byte> target = new byte[10240];
@@ -163,7 +163,7 @@ namespace FlatSharpTests
                 4, 0,                // offset of index 0 field
                 0, 0,                // padding to 4-byte alignment
                 3, 0, 0, 0,          // vector length
-                1, 0, 1,             // True false true
+                1, 2, 3,             // True false true
             };
 
             Assert.IsTrue(expectedResult.AsSpan().SequenceEqual(target));


### PR DESCRIPTION
Memory support for types other than byte needs to go. For precompiled serializers, this can lead to endianness issues using a precompiled serializer generated on a little-endian system on a big-endian system. This design worked with original versions of FlatSharp when schemas were only compiled at runtime, but that assertion got dropped when the compiler was added, and it's a feature that doesn't provide a lot of value (you can always do your own encoding of... whatever inside a byte array). List and array vectors are unaffected by this change.