### PR TITLE
Separate out legacy benchmarks

### DIFF
--- a/src/Benchmark.3.0.0/Benchmark.3.0.0.csproj
+++ b/src/Benchmark.3.0.0/Benchmark.3.0.0.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\netfx.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <DelaySign>false</DelaySign>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>
+    <DefineConstants>$(DefineConstants);NO_SHARED_STRINGS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="FlatSharp" Version="3.0.0" />
+    <PackageReference Include="FlatSharp.Runtime" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="protobuf-net" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Benchmark\FBBench\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\Benchmark\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.FlatBuffers\Google.FlatBuffers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Benchmark.3.2.0/Benchmark.3.2.0.csproj
+++ b/src/Benchmark.3.2.0/Benchmark.3.2.0.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\netfx.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <DelaySign>false</DelaySign>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>
+    <DefineConstants>$(DefineConstants);NO_SHARED_STRINGS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="FlatSharp" Version="3.2.0" />
+    <PackageReference Include="FlatSharp.Runtime" Version="3.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="protobuf-net" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Benchmark\FBBench\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\Benchmark\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.FlatBuffers\Google.FlatBuffers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Benchmark.3.3.0/Benchmark.3.3.0.csproj
+++ b/src/Benchmark.3.3.0/Benchmark.3.3.0.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\netfx.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <DelaySign>false</DelaySign>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="FlatSharp" Version="3.3.1" />
+    <PackageReference Include="FlatSharp.Runtime" Version="3.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="protobuf-net" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Benchmark\FBBench\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\Benchmark\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.FlatBuffers\Google.FlatBuffers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Benchmark/FBBench/FBDeserializeBench.cs
+++ b/src/Benchmark/FBBench/FBDeserializeBench.cs
@@ -18,7 +18,6 @@ namespace Benchmark.FBBench
 {
     using BenchmarkDotNet.Attributes;
     using FlatSharp;
-    using FlatSharp.Unsafe;
     using System;
 
     public class FBDeserializeBench : FBBenchCore

--- a/src/Benchmark/FBBench/FBSharedStringsBench.cs
+++ b/src/Benchmark/FBBench/FBSharedStringsBench.cs
@@ -16,6 +16,8 @@
 
 namespace Benchmark.FBBench
 {
+#if !NO_SHARED_STRINGS
+
     using BenchmarkDotNet.Attributes;
     using FlatSharp;
     using FlatSharp.Attributes;
@@ -162,4 +164,6 @@ namespace Benchmark.FBBench
             return rand_normal;
         }
     }
+
+#endif
 }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -33,7 +33,10 @@ namespace Benchmark
             summaries.Add(BenchmarkRunner.Run<FBBench.FBSerializeBench>());
             summaries.Add(BenchmarkRunner.Run<FBBench.FBDeserializeBench>());
             summaries.Add(BenchmarkRunner.Run<FBBench.OthersDeserializeBench>());
+
+#if !NO_SHARED_STRINGS
             summaries.Add(BenchmarkRunner.Run<FBBench.FBSharedStringBench>());
+#endif
 
             foreach (var item in summaries)
             {

--- a/src/FlatSharp.sln
+++ b/src/FlatSharp.sln
@@ -19,6 +19,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatSharp.Compiler", "FlatS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatSharp.Runtime", "FlatSharp.Runtime\FlatSharp.Runtime.csproj", "{07B42C28-D362-49D5-91D6-795634FF49AA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{83478353-8C5A-41C2-84C2-F79488B43CB0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark.3.0.0", "Benchmark.3.0.0\Benchmark.3.0.0.csproj", "{9EFCF7A1-59E8-4926-8CCB-5DACD1294887}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark.3.2.0", "Benchmark.3.2.0\Benchmark.3.2.0.csproj", "{2111D75B-E3B1-4F8A-948A-7505215CBA41}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark.3.3.0", "Benchmark.3.3.0\Benchmark.3.3.0.csproj", "{87E539C3-FE9D-473A-8556-F719B3C3F70A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,9 +65,28 @@ Global
 		{07B42C28-D362-49D5-91D6-795634FF49AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07B42C28-D362-49D5-91D6-795634FF49AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07B42C28-D362-49D5-91D6-795634FF49AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EFCF7A1-59E8-4926-8CCB-5DACD1294887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EFCF7A1-59E8-4926-8CCB-5DACD1294887}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EFCF7A1-59E8-4926-8CCB-5DACD1294887}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EFCF7A1-59E8-4926-8CCB-5DACD1294887}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2111D75B-E3B1-4F8A-948A-7505215CBA41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2111D75B-E3B1-4F8A-948A-7505215CBA41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2111D75B-E3B1-4F8A-948A-7505215CBA41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2111D75B-E3B1-4F8A-948A-7505215CBA41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87E539C3-FE9D-473A-8556-F719B3C3F70A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87E539C3-FE9D-473A-8556-F719B3C3F70A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87E539C3-FE9D-473A-8556-F719B3C3F70A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87E539C3-FE9D-473A-8556-F719B3C3F70A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{70AAF4BA-C7B7-436B-ABD2-1B533CD0A4E0} = {83478353-8C5A-41C2-84C2-F79488B43CB0}
+		{428BC458-F33D-4A19-B2AB-C7CC5F0645B9} = {83478353-8C5A-41C2-84C2-F79488B43CB0}
+		{9EFCF7A1-59E8-4926-8CCB-5DACD1294887} = {83478353-8C5A-41C2-84C2-F79488B43CB0}
+		{2111D75B-E3B1-4F8A-948A-7505215CBA41} = {83478353-8C5A-41C2-84C2-F79488B43CB0}
+		{87E539C3-FE9D-473A-8556-F719B3C3F70A} = {83478353-8C5A-41C2-84C2-F79488B43CB0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {726A4C0E-5760-4B35-8C73-9AC21B2E4C8B}


### PR DESCRIPTION
Keep legacy benchmarks that reference published versions of FlatSharp so we can test older code against newer benchmarks.