### PR TITLE
Added support for 'id' table field attribute

### DIFF
--- a/src/FlatSharp.Compiler/BaseSchemaMember.cs
+++ b/src/FlatSharp.Compiler/BaseSchemaMember.cs
@@ -77,7 +77,7 @@ namespace FlatSharp.Compiler
                 this.Name, () => this.OnGetCopyExpression(source));
         }
 
-        protected virtual void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializer)
+        protected virtual void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
         }
 

--- a/src/FlatSharp.Compiler/TypeDefinitions/EnumDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/EnumDefinition.cs
@@ -85,7 +85,7 @@ namespace FlatSharp.Compiler
             }
         }
 
-        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerailizers)
+        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             writer.AppendLine($"[FlatBufferEnum(typeof({this.UnderlyingType.ClrType.FullName}))]");
             writer.AppendLine("[System.Runtime.CompilerServices.CompilerGenerated]");

--- a/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
@@ -24,6 +24,8 @@ namespace FlatSharp.Compiler
     {
         public int Index { get; set; }
 
+        public bool IsIndexSetManually { get; set; }
+
         public string Name { get; set; }
 
         public string FbsFieldType { get; set; }

--- a/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
@@ -111,7 +111,7 @@ namespace FlatSharp.Compiler
                     ? builtInType.ClrType.FullName 
                     : typeDefinition?.GlobalName ?? FbsFieldType;
 
-                var defaultValue = GetDefaultValue(isBuiltInType, builtInType, enumDefinition, clrType);
+                var defaultValue = GetDefaultValue(builtInType, enumDefinition, clrType);
 
                 VerifySetterKindIsValid();
 
@@ -119,7 +119,7 @@ namespace FlatSharp.Compiler
             }));
         }
 
-        private string GetDefaultValue(bool isBuiltInType, ITypeModel builtInType, EnumDefinition enumDefinition, string clrType)
+        private string GetDefaultValue(ITypeModel builtInType, EnumDefinition enumDefinition, string clrType)
         {
             if (string.IsNullOrEmpty(DefaultValue))
             {

--- a/src/FlatSharp.Compiler/TypeDefinitions/NamespaceDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/NamespaceDefinition.cs
@@ -26,7 +26,7 @@ namespace FlatSharp.Compiler
 
         protected override bool SupportsChildren => true;
 
-        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerailizers)
+        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             writer.AppendLine($"namespace {this.Name}");
             writer.AppendLine($"{{");
@@ -34,7 +34,7 @@ namespace FlatSharp.Compiler
             {
                 foreach (var type in this.Children.Values)
                 {
-                    type.WriteCode(writer, pass, forFile, precompiledSerailizers);
+                    type.WriteCode(writer, pass, forFile, precompiledSerializers);
                 }
             }
             writer.AppendLine($"}}");

--- a/src/FlatSharp.Compiler/TypeDefinitions/RootNodeDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/RootNodeDefinition.cs
@@ -35,7 +35,7 @@ namespace FlatSharp.Compiler
 
         protected override bool SupportsChildren => true;
 
-        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerailizers)
+        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             writer.AppendLine($@"
 //------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ namespace FlatSharp.Compiler
 
             foreach (var child in this.Children.Values)
             {
-                child.WriteCode(writer, pass, forFile, precompiledSerailizers);
+                child.WriteCode(writer, pass, forFile, precompiledSerializers);
             }
         }
 

--- a/src/FlatSharp.Compiler/TypeDefinitions/RpcDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/RpcDefinition.cs
@@ -73,7 +73,7 @@ namespace FlatSharp.Compiler
 
         protected override bool SupportsChildren => false;
 
-        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializer)
+        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             if (pass == CodeWritingPass.FirstPass)
             {

--- a/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
@@ -42,8 +42,7 @@ namespace FlatSharp.Compiler
 
         protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
-            this.AssignIndexes();
-
+            AssignIndexes();
             AppendTypeDefinition(writer);
 
             using (writer.IncreaseIndent())
@@ -55,12 +54,12 @@ namespace FlatSharp.Compiler
                 AppendSerializer(writer, pass, precompiledSerializers);
             }
 
-            writer.AppendLine($"}}");
+            writer.AppendLine("}");
         }
 
         protected override string OnGetCopyExpression(string source)
         {
-            return $"{source} != null ? new {this.FullName}({source}) : null";
+            return $"{source} != null ? new {FullName}({source}) : null";
         }
 
         private void AssignIndexes()

--- a/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
@@ -16,9 +16,7 @@
 
 namespace FlatSharp.Compiler
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     internal class TableOrStructDefinition : BaseSchemaMember
     {
@@ -42,81 +40,19 @@ namespace FlatSharp.Compiler
 
         protected override bool SupportsChildren => false;
 
-        public void AssignIndexes()
-        {
-            ErrorContext.Current.WithScope(this.Name, () =>
-            {
-                int nextIndex = 0;
-                for (int i = 0; i < this.Fields.Count; ++i)
-                {
-                    this.Fields[i].Index = nextIndex;
-
-                    nextIndex++;
-
-                    if (this.TryResolveName(this.Fields[i].FbsFieldType, out var typeDef) && typeDef is UnionDefinition)
-                    {
-                        // Unions are double-wide.
-                        nextIndex++;
-                    }
-                }
-            });
-        }
-
-        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerailizers)
+        protected override void OnWriteCode(CodeWriter writer, CodeWritingPass pass, string forFile, IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             this.AssignIndexes();
 
-            string attribute = this.IsTable ? "[FlatBufferTable]" : "[FlatBufferStruct]";
-
-            writer.AppendLine(attribute);
-            writer.AppendLine("[System.Runtime.CompilerServices.CompilerGenerated]");
-            writer.AppendLine($"public partial class {this.Name} : object");
-            writer.AppendLine($"{{");
+            AppendTypeDefinition(writer);
 
             using (writer.IncreaseIndent())
             {
-                writer.AppendLine($"partial void OnInitialized();");
-
-                // default ctor.
-                string obsolete = this.ObsoleteDefaultConstructor ? $"[Obsolete]" : string.Empty;
-                writer.AppendLine($"{obsolete} public {this.Name}() {{ this.OnInitialized(); }}");
-
-                writer.AppendLine($"public {this.Name}({this.Name} source)");
-                using (writer.WithBlock())
-                {
-                    foreach (var field in this.Fields)
-                    {
-                        field.WriteCopyConstructorLine(writer, "source", this);
-                    }
-
-                    writer.AppendLine("this.OnInitialized();");
-                }
-
-                foreach (var field in this.Fields)
-                {
-                    if (!this.IsTable && field.Deprecated)
-                    {
-                        ErrorContext.Current?.RegisterError($"FlatBuffer structs may not have deprecated fields.");
-                    }
-
-                    field.WriteField(writer, this);
-                }
-
-                if (pass == CodeWritingPass.SecondPass && precompiledSerailizers != null && this.RequestedSerializer != null)
-                {
-                    if (precompiledSerailizers.TryGetValue(this.FullName, out string serializer))
-                    {
-                        writer.AppendLine($"public static ISerializer<{this.FullName}> Serializer {{ get; }} = new {RoslynSerializerGenerator.GeneratedSerializerClassName}().AsISerializer();");
-                        writer.AppendLine(string.Empty);
-                        writer.AppendLine($"#region Serializer for {this.FullName}");
-                        writer.AppendLine(serializer);
-                        writer.AppendLine($"#endregion");
-                    }
-                    else
-                    {
-                        ErrorContext.Current.RegisterError($"Table {this.FullName} requested serializer, but none was found.");
-                    }
-                }
+                AppendRequiredMembers(writer);
+                AppendDefaultConstructor(writer);
+                AppendCopyConstructor(writer);
+                AppendFields(writer);
+                AppendSerializer(writer, pass, precompiledSerializers);
             }
 
             writer.AppendLine($"}}");
@@ -125,6 +61,103 @@ namespace FlatSharp.Compiler
         protected override string OnGetCopyExpression(string source)
         {
             return $"{source} != null ? new {this.FullName}({source}) : null";
+        }
+
+        private void AssignIndexes()
+        {
+            ErrorContext.Current.WithScope(
+                Name,
+                () =>
+                {
+                    int nextIndex = 0;
+                    foreach (var field in Fields)
+                    {
+                        field.Index = nextIndex;
+
+                        nextIndex++;
+
+                        if (TryResolveName(field.FbsFieldType, out var typeDef) &&
+                            typeDef is UnionDefinition)
+                        {
+                            // Unions are double-wide.
+                            nextIndex++;
+                        }
+                    }
+                });
+        }
+
+        private void AppendTypeDefinition(CodeWriter writer)
+        {
+            string attribute = IsTable ? "[FlatBufferTable]" : "[FlatBufferStruct]";
+
+            writer.AppendLine(attribute);
+            writer.AppendLine("[System.Runtime.CompilerServices.CompilerGenerated]");
+            writer.AppendLine($"public partial class {Name} : object");
+            writer.AppendLine("{");
+        }
+
+        private void AppendDefaultConstructor(CodeWriter writer)
+        {
+            string obsolete = ObsoleteDefaultConstructor ? "[Obsolete]" : string.Empty;
+            writer.AppendLine($"{obsolete} public {Name}() {{ this.OnInitialized(); }}");
+        }
+
+        private void AppendCopyConstructor(CodeWriter writer)
+        {
+            writer.AppendLine($"public {Name}({Name} source)");
+            using (writer.WithBlock())
+            {
+                foreach (var field in Fields)
+                {
+                    field.WriteCopyConstructorLine(writer, "source", this);
+                }
+
+                writer.AppendLine("this.OnInitialized();");
+            }
+        }
+
+        private static void AppendRequiredMembers(CodeWriter writer)
+        {
+            writer.AppendLine("partial void OnInitialized();");
+        }
+
+        private void AppendFields(CodeWriter writer)
+        {
+            foreach (var field in Fields)
+            {
+                if (!IsTable &&
+                    field.Deprecated)
+                {
+                    ErrorContext.Current?.RegisterError("FlatBuffer structs may not have deprecated fields.");
+                }
+
+                field.WriteField(writer, this);
+            }
+        }
+
+        private void AppendSerializer(CodeWriter writer, CodeWritingPass pass, IReadOnlyDictionary<string, string> precompiledSerializers)
+        {
+            if (pass != CodeWritingPass.SecondPass ||
+                precompiledSerializers == null ||
+                RequestedSerializer == null)
+            {
+                return;
+            }
+
+            if (precompiledSerializers.TryGetValue(FullName, out string serializer))
+            {
+                writer.AppendLine(
+                    $"public static ISerializer<{FullName}> Serializer {{ get; }} = new {RoslynSerializerGenerator.GeneratedSerializerClassName}().AsISerializer();");
+
+                writer.AppendLine(string.Empty);
+                writer.AppendLine($"#region Serializer for {FullName}");
+                writer.AppendLine(serializer);
+                writer.AppendLine("#endregion");
+            }
+            else
+            {
+                ErrorContext.Current.RegisterError($"Table {FullName} requested serializer, but none was found.");
+            }
         }
     }
 }

--- a/src/FlatSharp.Compiler/TypeDefinitions/UnionDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/UnionDefinition.cs
@@ -81,7 +81,7 @@ namespace FlatSharp.Compiler
             CodeWriter writer, 
             CodeWritingPass pass, 
             string forFile, 
-            IReadOnlyDictionary<string, string> precompiledSerializer)
+            IReadOnlyDictionary<string, string> precompiledSerializers)
         {
             if (!this.GenerateCustomUnionType)
             {

--- a/src/FlatSharp.sln.DotSettings
+++ b/src/FlatSharp.sln.DotSettings
@@ -1,0 +1,11 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AFTER_MULTILINE_STATEMENTS/@EntryValue">1</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_BEFORE_BLOCK_STATEMENTS/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_EXPR_PROPERTY_ON_SINGLE_LINE/@EntryValue">ALWAYS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/USE_INDENT_FROM_VS/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">160</s:Int64>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=e1596b60_002Dc017_002D4759_002Db67a_002D6ba895aba5fe/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Solution /&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
- 'id' attribute now can be specified and used by FlatSharp.
- 'id' attribute allowed only of table fields. It's not allowed on struct fields.
- All or none of fields should have - 'id' attribute set.
- 'id' attribute value can not be negative.
- 'id' attribute should have value if present.