### PR TITLE
Namespaced compiler attributes

### DIFF
--- a/src/Benchmark.3.0.0/Benchmark.3.0.0.csproj
+++ b/src/Benchmark.3.0.0/Benchmark.3.0.0.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <DelaySign>false</DelaySign>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>

--- a/src/Benchmark.3.2.0/Benchmark.3.2.0.csproj
+++ b/src/Benchmark.3.2.0/Benchmark.3.2.0.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <DelaySign>false</DelaySign>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>

--- a/src/Benchmark.3.3.0/Benchmark.3.3.0.csproj
+++ b/src/Benchmark.3.3.0/Benchmark.3.3.0.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <DelaySign>false</DelaySign>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>

--- a/src/Benchmark.4.0.0/Benchmark.4.0.0.csproj
+++ b/src/Benchmark.4.0.0/Benchmark.4.0.0.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <DelaySign>false</DelaySign>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -3,11 +3,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <DelaySign>false</DelaySign>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\misc\strongname.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>$(DefineContants);FLATSHARP_NONVIRTUAL</DefineConstants>
+    <DefineConstants>$(DefineContants);RUN_COMPARISON_BENCHMARKS;CURRENT_VERSION_ONLY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Benchmark/FBBench/FBBenchCore.cs
+++ b/src/Benchmark/FBBench/FBBenchCore.cs
@@ -30,9 +30,7 @@ namespace Benchmark.FBBench
 
     using JobKind = BenchmarkDotNet.Attributes.MediumRunJobAttribute;
 
-    [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.Net47)]
     [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp31)]
-    [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp21)]
     [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp50)]
     [CsvExporter(BenchmarkDotNet.Exporters.Csv.CsvSeparator.Comma)]
     public abstract class FBBenchCore

--- a/src/Benchmark/FBBench/FBSerializeBench.cs
+++ b/src/Benchmark/FBBench/FBSerializeBench.cs
@@ -20,6 +20,7 @@ namespace Benchmark.FBBench
 
     public class FBSerializeBench : FBBenchCore
     {
+#if RUN_COMPARISON_BENCHMARKS
         [Benchmark]
         public override void Google_FlatBuffers_Serialize() => base.Google_FlatBuffers_Serialize();
 
@@ -39,6 +40,16 @@ namespace Benchmark.FBBench
         public override void Google_Flatbuffers_IntVector_Unsorted() => base.Google_Flatbuffers_IntVector_Unsorted();
 
         [Benchmark]
+        public override void PBDN_Serialize() => base.PBDN_Serialize();
+
+        [Benchmark]
+        public override void PBDN_Serialize_NonVirtual() => base.PBDN_Serialize_NonVirtual();
+
+        [Benchmark]
+        public override void MsgPack_Serialize_NonVirtual() => base.MsgPack_Serialize_NonVirtual();
+#endif
+
+        [Benchmark]
         public override void FlatSharp_GetMaxSize() => base.FlatSharp_GetMaxSize();
 
         [Benchmark]
@@ -46,12 +57,6 @@ namespace Benchmark.FBBench
 
         [Benchmark]
         public override void FlatSharp_Serialize_NonVirtual() => base.FlatSharp_Serialize_NonVirtual();
-
-        [Benchmark]
-        public override void PBDN_Serialize() => base.PBDN_Serialize();
-
-        [Benchmark]
-        public override void PBDN_Serialize_NonVirtual() => base.PBDN_Serialize_NonVirtual();
 
         [Benchmark]
         public override void FlatSharp_Serialize_StringVector_Sorted() => base.FlatSharp_Serialize_StringVector_Sorted();
@@ -67,8 +72,5 @@ namespace Benchmark.FBBench
 
         [Benchmark]
         public override void FlatSharp_Serialize_ValueTableVector() => base.FlatSharp_Serialize_ValueTableVector();
-
-        [Benchmark]
-        public override void MsgPack_Serialize_NonVirtual() => base.MsgPack_Serialize_NonVirtual();
     }
 }

--- a/src/Benchmark/FBBench/OthersDeserializeBench.cs
+++ b/src/Benchmark/FBBench/OthersDeserializeBench.cs
@@ -26,6 +26,7 @@ namespace Benchmark.FBBench
         [Params(1, 5)]
         public override int TraversalCount { get; set; }
 
+#if RUN_COMPARISON_BENCHMARKS
         [Benchmark]
         public override int Google_Flatbuffers_ParseAndTraverse() => base.Google_Flatbuffers_ParseAndTraverse();
 
@@ -55,5 +56,6 @@ namespace Benchmark.FBBench
 
         [Benchmark]
         public override void MsgPack_ParseAndTraversePartial() => base.MsgPack_ParseAndTraversePartial();
+#endif
     }
 }

--- a/src/ExperimentalBenchmark/ExperimentalBenchmark.csproj
+++ b/src/ExperimentalBenchmark/ExperimentalBenchmark.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DelaySign>false</DelaySign>

--- a/src/FlatSharp.Compiler/MetdataKeys.cs
+++ b/src/FlatSharp.Compiler/MetdataKeys.cs
@@ -1,0 +1,112 @@
+﻿/*
+ * Copyright 2021 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace FlatSharp.Compiler
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Names of attributes specified in FBS files.
+    /// </summary>
+    public static class MetdataKeys
+    {
+        /// <summary>
+        /// Controls the type of serializer generated for the given table.
+        /// Valid On:
+        /// - Table
+        /// </summary>
+        public const string SerializerKind = "fs_serializer";
+        public const string PrecompiledSerializerLegacy = "PrecompiledSerializer";
+
+        /// <summary>
+        /// Controls whether fields are virtual or non-virtual. They are virtual by default.
+        /// Valid On:
+        /// - Table (as a default for all fields in the table, overridden by the setting on a field)
+        /// - Struct (as a default for all fields in the struct, overridden by the setting on a field)
+        /// - Field 
+        /// </summary>
+        public const string NonVirtualProperty = "fs_nonVirtual";
+        public const string NonVirtualPropertyLegacy = "nonVirtual";
+
+        /// <summary>
+        /// Controls whether a vector field should be sorted or not. The field must be a vector.
+        /// Valid On:
+        /// - Field 
+        /// </summary>
+        public const string SortedVector = "fs_sortedVector";
+        public const string SortedVectorLegacy = "sortedvector";
+
+        /// <summary>
+        /// Controls whether FlatSharp should model the string or string vector as a SharedString for string deduplication.
+        /// Valid On:
+        /// - String Field or Vector of String field
+        /// </summary>
+        public const string SharedString = "fs_sharedString";
+        public const string SharedStringLegacy = "sharedstring";
+
+        /// <summary>
+        /// Controls whether FlatSharp should add a [Obsolete] attribute to the default constructor to prevent unintended usage.
+        /// Valid On:
+        /// - Table
+        /// - Struct
+        /// </summary>
+        public const string ObsoleteDefaultConstructor = "fs_obsoleteCtor";
+        public const string ObsoleteDefaultConstructorLegacy = "obsoleteDefaultConstructor";
+
+        /// <summary>
+        /// Controls the type of vector FlatSharp will generate. Valid values can be found in <see cref="VectorType"/>.
+        /// Valid On:
+        /// - Table vector field
+        /// </summary>
+        public const string VectorKind = "fs_vector";
+        public const string VectorKindLegacy = "VectorType";
+
+        /// <summary>
+        /// Controls the type of setter FlatSharp will generate for a given field. Valid values can be found in <see cref="SetterKind"/>.
+        /// Valid On:
+        /// - Table field
+        /// - Struct field
+        /// </summary>
+        public const string Setter = "fs_setter";
+        public const string SetterLegacy = "setter";
+
+        /// <summary>
+        /// Marks a table field as deprecated. Deprecated fields do not have their values serialized or parsed.
+        /// Valid On:
+        /// - Table field
+        /// </summary>
+        public const string Deprecated = "deprecated";
+
+        /// <summary>
+        /// Marks a table field as being the key to a sorted vector.
+        /// Valid On:
+        /// - Table field, with the type of string or scalar.
+        /// </summary>
+        public const string Key = "key";
+
+        /// <summary>
+        /// Defines an explicit ID for a table field, so fields can be out-of-order in the FBS file.
+        /// Valid On:
+        /// - Table field
+        /// </summary>
+        public const string Id = "id";
+
+        public static IEnumerable<string> UnsupportedStandardAttributes => new[]
+        {
+            "required", "force_align", "bit_flags", "flexbuffer", "hash", "original_order"
+        };
+    }
+}

--- a/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/FieldDefinition.cs
@@ -323,7 +323,7 @@ namespace FlatSharp.Compiler
                     return clrType;
 
                 default:
-                    throw new InvalidOperationException($"Unexpected value for vectortype: '{vectorType}'");
+                    throw new InvalidOperationException($"Unexpected value for '{MetdataKeys.VectorKind}': '{vectorType}'");
             }
         }
     }

--- a/src/FlatSharp.Compiler/TypeDefinitions/RpcDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/RpcDefinition.cs
@@ -135,7 +135,7 @@ namespace FlatSharp.Compiler
                 {
                     if (typeModel.ClrType.GetProperty(TableOrStructDefinition.SerializerPropertyName, BindingFlags.Static | BindingFlags.Public) == null)
                     {
-                        ErrorContext.Current.RegisterError("Types declared in RPC definitions must have PrecompiledSerializers enabled.");
+                        ErrorContext.Current.RegisterError($"Types declared in RPC definitions must have serializers enabled using the '{MetdataKeys.SerializerKind}' attribute.");
                         return false;
                     }
                 }

--- a/src/FlatSharp.Compiler/Visitors/MetadataVisitor.cs
+++ b/src/FlatSharp.Compiler/Visitors/MetadataVisitor.cs
@@ -44,6 +44,14 @@ namespace FlatSharp.Compiler
                 }
             }
 
+            foreach (var unsupportedAttribute in MetdataKeys.UnsupportedStandardAttributes)
+            {
+                if (pairs.ContainsKey(unsupportedAttribute))
+                {
+                    ErrorContext.Current?.RegisterError($"FlatSharpCompiler does not support the '{unsupportedAttribute}' attribute in FBS files.");
+                }
+            }
+
             return pairs;
         }
     }

--- a/src/FlatSharp.Compiler/Visitors/TypeVisitor.cs
+++ b/src/FlatSharp.Compiler/Visitors/TypeVisitor.cs
@@ -43,18 +43,18 @@ namespace FlatSharp.Compiler
             {
                 definition.IsTable = context.GetChild(0).GetText() == "table";
 
-                definition.NonVirtual = metadata.ParseNullableBooleanMetadata("nonVirtual");
-                definition.ObsoleteDefaultConstructor = metadata.ParseBooleanMetadata("obsoleteDefaultConstructor");
+                definition.NonVirtual = metadata.ParseNullableBooleanMetadata(MetdataKeys.NonVirtualProperty, MetdataKeys.NonVirtualPropertyLegacy);
+                definition.ObsoleteDefaultConstructor = metadata.ParseBooleanMetadata(MetdataKeys.ObsoleteDefaultConstructor, MetdataKeys.ObsoleteDefaultConstructorLegacy);
 
                 definition.RequestedSerializer = metadata.ParseMetadata<FlatBufferDeserializationOption?>(
-                    "PrecompiledSerializer",
+                    new[] { MetdataKeys.SerializerKind, MetdataKeys.PrecompiledSerializerLegacy },
                     ParseSerailizerFlags,
                     FlatBufferDeserializationOption.Default,
                     null);
 
                 if (!definition.IsTable && definition.RequestedSerializer != null)
                 {
-                    ErrorContext.Current.RegisterError("Structs may not have precompiled serializers.");
+                    ErrorContext.Current.RegisterError("Structs may not have serializers.");
                 }
 
                 var fields = context.field_decl();

--- a/src/FlatSharpTests/FlatSharpCompiler/AccessModifierTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/AccessModifierTests.cs
@@ -56,17 +56,17 @@ namespace FlatSharpTests.Compiler
         {
             string schema = $@"
             namespace VirtualTests;
-            table VirtualTable (PrecompiledSerializer:""{option}"") {{
-                Default:int (setter:""{setterKind}"");
-                ForcedVirtual:int (nonVirtual:""false"", setter:""{setterKind}"");
-                ForcedNonVirtual:int (nonVirtual:""true"", setter:""{(setterKind != SetterKind.None ? setterKind : SetterKind.Public)}"");
+            table VirtualTable ({MetdataKeys.SerializerKind}:""{option}"") {{
+                Default:int ({MetdataKeys.Setter}:""{setterKind}"");
+                ForcedVirtual:int ({MetdataKeys.NonVirtualProperty}:""false"", {MetdataKeys.SetterLegacy}:""{setterKind}"");
+                ForcedNonVirtual:int ({MetdataKeys.NonVirtualProperty}:""true"", {MetdataKeys.Setter}:""{(setterKind != SetterKind.None ? setterKind : SetterKind.Public)}"");
                 Struct:VirtualStruct;
             }}
 
             struct VirtualStruct {{
-                Default:int (setter:""{setterKind}"");
-                ForcedVirtual:int (nonVirtual:""false"", setter:""{setterKind}"");
-                ForcedNonVirtual:int (nonVirtual:""true"", setter:""{(setterKind != SetterKind.None ? setterKind : SetterKind.Public)}"");
+                Default:int ({MetdataKeys.Setter}:""{setterKind}"");
+                ForcedVirtual:int ({MetdataKeys.NonVirtualProperty}:""false"", setter:""{setterKind}"");
+                ForcedNonVirtual:int ({MetdataKeys.NonVirtualProperty}:""true"", setter:""{(setterKind != SetterKind.None ? setterKind : SetterKind.Public)}"");
             }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());

--- a/src/FlatSharpTests/FlatSharpCompiler/CopyConstructorTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/CopyConstructorTests.cs
@@ -33,12 +33,12 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void CopyConstructorsTest()
         {
-            string schema = @"
+            string schema = $@"
 namespace CopyConstructorTest;
 
-union Union { OuterTable, InnerTable, OuterStruct, InnerStruct } // Optionally add more tables.
+union Union {{ OuterTable, InnerTable, OuterStruct, InnerStruct }} // Optionally add more tables.
 
-table OuterTable (PrecompiledSerializer: ""Greedy"") {
+table OuterTable ({MetdataKeys.SerializerKind}: ""Greedy"") {{
   A:string;
 
   B:byte;
@@ -50,33 +50,33 @@ table OuterTable (PrecompiledSerializer: ""Greedy"") {
   H:int64;
   I:uint64;
   
-  IntVector_List:[int] (VectorType:""IList"");
-  IntVector_RoList:[int] (VectorType:""IReadOnlyList"");
-  IntVector_Array:[int] (VectorType:""Array"");
+  IntVector_List:[int] ({MetdataKeys.VectorKind}:""IList"");
+  IntVector_RoList:[int] ({MetdataKeys.VectorKind}:""IReadOnlyList"");
+  IntVector_Array:[int] ({MetdataKeys.VectorKind}:""Array"");
   
-  TableVector_List:[InnerTable] (VectorType:""IList"");
-  TableVector_RoList:[InnerTable] (VectorType:""IReadOnlyList"");
-  TableVector_Indexed:[InnerTable] (VectorType:""IIndexedVector"");
-  TableVector_Array:[InnerTable] (VectorType:""Array"");
+  TableVector_List:[InnerTable] ({MetdataKeys.VectorKind}:""IList"");
+  TableVector_RoList:[InnerTable] ({MetdataKeys.VectorKind}:""IReadOnlyList"");
+  TableVector_Indexed:[InnerTable] ({MetdataKeys.VectorKind}:""IIndexedVector"");
+  TableVector_Array:[InnerTable] ({MetdataKeys.VectorKindLegacy}:""Array"");
 
-  ByteVector:[ubyte] (VectorType:""Memory"");
-  ByteVector_RO:[ubyte] (VectorType:""ReadOnlyMemory"");
+  ByteVector:[ubyte] ({MetdataKeys.VectorKind}:""Memory"");
+  ByteVector_RO:[ubyte] ({MetdataKeys.VectorKind}:""ReadOnlyMemory"");
   Union:Union;
-}
+}}
 
-struct OuterStruct {
+struct OuterStruct {{
     Value:int;
     InnerStruct:InnerStruct;
-}
+}}
 
-struct InnerStruct {
+struct InnerStruct {{
     LongValue:int64;
-}
+}}
 
-table InnerTable {
-  Name:string (key);
+table InnerTable {{
+  Name:string ({MetdataKeys.Key});
   OuterStruct:OuterStruct;
-}
+}}
 
 ";
             OuterTable original = new OuterTable

--- a/src/FlatSharpTests/FlatSharpCompiler/Grpc/GrpcTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/Grpc/GrpcTests.cs
@@ -29,51 +29,51 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void RouteGuideTest()
         {
-            string schema = @"
+            string schema = $@"
 namespace routeguide;
 
     rpc_service RouteGuide
-    {
+    {{
         GetFeature(Point):Feature;
         ListFeatures(Rectangle):Feature (streaming:server);
         RecordRoute(Point):RouteSummary (streaming:client);
         RouteChat(RouteNote):RouteNote (streaming:duplex);
-    }
+    }}
 
-    table Point (PrecompiledSerializer:lazy)
-    {
+    table Point ({MetdataKeys.SerializerKind}:lazy)
+    {{
         latitude:int32;
         longitude:int32;
-    }
+    }}
 
-    table Rectangle (PrecompiledSerializer:lazy)
-    {
+    table Rectangle ({MetdataKeys.PrecompiledSerializerLegacy}:lazy)
+    {{
         lo:Point;
         hi:Point;
-    }
+    }}
 
-    table Feature (PrecompiledSerializer:lazy)
-    {
+    table Feature ({MetdataKeys.SerializerKind}:lazy)
+    {{
         // The name of the feature.
         name:string;
 
         // The point where the feature is detected.
         location:Point;
-    }
+    }}
 
-    table RouteNote (PrecompiledSerializer:lazy)
-    {
+    table RouteNote ({MetdataKeys.SerializerKind}:lazy)
+    {{
         location:Point;
         message:string;
-    }
+    }}
 
-    table RouteSummary (PrecompiledSerializer:greedymutable)
-    {
+    table RouteSummary ({MetdataKeys.SerializerKind}:greedymutable)
+    {{
         point_count:int;
         feature_count:int;
         distance:int;
         elapsed_time:int;
-    }";
+    }}";
             Assembly compiled = FlatSharpCompiler.CompileAndLoadAssembly(
                 schema,
                 new(),
@@ -111,19 +111,19 @@ namespace routeguide;
         [TestMethod]
         public void RpcUnknownType()
         {
-            string schema = @"
+            string schema = $@"
 namespace RpcUnknownType;
 
     rpc_service RouteGuide
-    {
+    {{
         GetFeature(NotExisting):Point;
-    }
+    }}
 
-    table Point (PrecompiledSerializer:lazy)
-    {
+    table Point ({MetdataKeys.SerializerKind}:lazy)
+    {{
         latitude:int32;
         longitude:int32;
-    }";
+    }}";
 
             Assert.ThrowsException<InvalidFbsFileException>(() => FlatSharpCompiler.TestHookCreateCSharp(schema, new()));
         }
@@ -131,19 +131,19 @@ namespace RpcUnknownType;
         [TestMethod]
         public void RpcUnknownStreamingType()
         {
-            string schema = @"
+            string schema = $@"
 namespace RpcUnknownStreamingType;
 
     rpc_service RouteGuide
-    {
+    {{
         GetFeature(Point):Point (streaming:banana);
-    }
+    }}
 
-    table Point (PrecompiledSerializer:lazy)
-    {
+    table Point ({MetdataKeys.SerializerKind}:lazy)
+    {{
         latitude:int32;
         longitude:int32;
-    }";
+    }}";
 
             Assert.ThrowsException<InvalidFbsFileException>(() => FlatSharpCompiler.TestHookCreateCSharp(schema, new()));
         }
@@ -151,19 +151,19 @@ namespace RpcUnknownStreamingType;
         [TestMethod]
         public void RpcReturnsAStruct()
         {
-            string schema = @"
+            string schema = $@"
 namespace RpcReturnsAStruct;
 
     rpc_service RouteGuide
-    {
+    {{
         GetFeature(Point):Point;
-    }
+    }}
 
-    struct Point (PrecompiledSerializer:lazy)
-    {
+    struct Point ({MetdataKeys.SerializerKind}:lazy)
+    {{
         latitude:int32;
         longitude:int32;
-    }";
+    }}";
 
             Assert.ThrowsException<InvalidFbsFileException>(() => FlatSharpCompiler.TestHookCreateCSharp(schema, new()));
         }
@@ -171,19 +171,19 @@ namespace RpcReturnsAStruct;
         [TestMethod]
         public void NoPrecompiledSerializer()
         {
-            string schema = @"
+            string schema = $@"
 namespace NoPrecompiledSerializer;
 
     rpc_service RouteGuide
-    {
+    {{
         GetFeature(Point):Point;
-    }
+    }}
 
     table Point
-    {
+    {{
         latitude:int32;
         longitude:int32;
-    }";
+    }}";
 
             Assert.ThrowsException<InvalidFbsFileException>(() => FlatSharpCompiler.TestHookCreateCSharp(schema, new()));
         }

--- a/src/FlatSharpTests/FlatSharpCompiler/IncludeTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/IncludeTests.cs
@@ -100,10 +100,10 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void CircularReferenceInclude()
         {
-            string baseFbs = "include \"A.fbs\"; namespace Foo; table BaseTable (PrecompiledSerializer) { OtherTable:OtherTable; }";
+            string baseFbs = $"include \"A.fbs\"; namespace Foo; table BaseTable ({MetdataKeys.SerializerKind}) {{ OtherTable:OtherTable; }}";
             var includes = new Dictionary<string, string>
             {
-                { "A.fbs", "include \"root.fbs\"; namespace Foo; table OtherTable (PrecompiledSerializer) { Foo:BaseTable; }" },
+                { "A.fbs", $"include \"root.fbs\"; namespace Foo; table OtherTable ({MetdataKeys.SerializerKind}) {{ Foo:BaseTable; }}" },
             };
 
             string cSharp = FlatSharpCompiler.TestHookCreateCSharp(baseFbs, new(), includes);
@@ -136,7 +136,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void DuplicateTypesDifferentFiles()
         {
-            string baseFbs = "include \"A.fbs\"; namespace Foo; table BaseTable (PrecompiledSerializer) { BaseTable:BaseTable; }";
+            string baseFbs = $"include \"A.fbs\"; namespace Foo; table BaseTable ({MetdataKeys.SerializerKind}) {{ BaseTable:BaseTable; }}";
             var includes = new Dictionary<string, string>
             {
                 { "A.fbs", "namespace Foo; table BaseTable { BaseTable:BaseTable; }" },

--- a/src/FlatSharpTests/FlatSharpCompiler/MetadataTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/MetadataTests.cs
@@ -32,7 +32,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void DeprecatedMetadata()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("", "string", "deprecated");
+            var (prop, type, attribute) = this.CompileAndGetProperty("", "string", MetdataKeys.Deprecated);
             Assert.IsTrue(attribute.Deprecated);
             Assert.IsFalse(attribute.SortedVector);
         }
@@ -40,7 +40,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void DeprecatedSortedVector()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("", "[OtherTable]", "deprecated,sortedvector");
+            var (prop, type, attribute) = this.CompileAndGetProperty("", "[OtherTable]", $"{MetdataKeys.Deprecated},{MetdataKeys.SortedVector}");
             Assert.IsTrue(attribute.Deprecated);
             Assert.IsTrue(attribute.SortedVector);
         }
@@ -48,7 +48,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void VectorTypeUnquoted()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("", "[string]", "VectorType:Array");
+            var (prop, type, attribute) = this.CompileAndGetProperty("", "[string]", $"{MetdataKeys.VectorKind}:Array");
             Assert.IsFalse(attribute.Deprecated);
             Assert.IsFalse(attribute.SortedVector);
             Assert.AreEqual(typeof(string[]), prop.PropertyType);
@@ -57,7 +57,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void VectorTypeQuoted()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("", "[string]", "VectorType:\"IList\"");
+            var (prop, type, attribute) = this.CompileAndGetProperty("", "[string]", $"{MetdataKeys.VectorKind}:\"IList\"");
             Assert.IsFalse(attribute.Deprecated);
             Assert.IsFalse(attribute.SortedVector);
             Assert.AreEqual(typeof(IList<string>), prop.PropertyType);
@@ -66,7 +66,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void IIndexedVector()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("", "[OtherTable]", "VectorType:\"IIndexedVector\",SortedVector");
+            var (prop, type, attribute) = this.CompileAndGetProperty("", "[OtherTable]", $"{MetdataKeys.VectorKind}:\"IIndexedVector\",{MetdataKeys.SortedVector}");
 
             Assert.IsFalse(attribute.Deprecated);
             Assert.IsTrue(attribute.SortedVector);
@@ -78,7 +78,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void IIndexedVectorVector_WithSerializer()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("PrecompiledSerializer", "[OtherTable]", "VectorType:\"IIndexedVector\",SortedVector");
+            var (prop, type, attribute) = this.CompileAndGetProperty(MetdataKeys.SerializerKind, "[OtherTable]", $"{MetdataKeys.VectorKind}:\"IIndexedVector\",{MetdataKeys.SortedVector}");
 
             Assert.IsFalse(attribute.Deprecated);
             Assert.IsTrue(attribute.SortedVector);
@@ -90,7 +90,7 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void IIndexedVector_WithSerializer_NoSortedDeclaration()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("PrecompiledSerializer", "[OtherTable]", "VectorType:\"IIndexedVector\"");
+            var (prop, type, attribute) = this.CompileAndGetProperty(MetdataKeys.SerializerKind, "[OtherTable]", $"{MetdataKeys.VectorKind}:\"IIndexedVector\"");
 
             Assert.IsFalse(attribute.Deprecated);
             Assert.IsFalse(attribute.SortedVector); // dictionaries override this attribute.
@@ -102,21 +102,21 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void PrecompiledSerializer()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("PrecompiledSerializer", "string", "");
+            var (prop, type, attribute) = this.CompileAndGetProperty(MetdataKeys.SerializerKind, "string", "");
             Assert.AreEqual(type.GetNestedType("GeneratedSerializer", BindingFlags.NonPublic).GetCustomAttribute<FlatSharpGeneratedSerializerAttribute>().DeserializationOption, FlatBufferDeserializationOption.GreedyMutable);
         }
 
         [TestMethod]
         public void PrecompiledSerializerQuoted()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("PrecompiledSerializer:\"Lazy\"", "string", "");
+            var (prop, type, attribute) = this.CompileAndGetProperty($"{MetdataKeys.SerializerKind}:\"Lazy\"", "string", "");
             Assert.AreEqual(type.GetNestedType("GeneratedSerializer", BindingFlags.NonPublic).GetCustomAttribute<FlatSharpGeneratedSerializerAttribute>().DeserializationOption, FlatBufferDeserializationOption.Lazy);
         }
 
         [TestMethod]
         public void PrecompiledSerializerUnquoted()
         {
-            var (prop, type, attribute) = this.CompileAndGetProperty("PrecompiledSerializer:VectorCacheMutable", "string", "");
+            var (prop, type, attribute) = this.CompileAndGetProperty($"{MetdataKeys.SerializerKind}:VectorCacheMutable", "string", "");
             Assert.AreEqual(type.GetNestedType("GeneratedSerializer", BindingFlags.NonPublic).GetCustomAttribute<FlatSharpGeneratedSerializerAttribute>().DeserializationOption, FlatBufferDeserializationOption.VectorCacheMutable);
         }
 

--- a/src/FlatSharpTests/FlatSharpCompiler/NullableAnnotationTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/NullableAnnotationTests.cs
@@ -29,28 +29,28 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void NullableAnnotations()
         {
-            string schema = @"
+            string schema = $@"
             namespace NullableAnnotationTests;
 
-            table Table {
+            table Table ({MetdataKeys.SerializerKind}) {{
                 foo:Foo;
                 defaultInt:int32 = 3;
                 str:string;
                 nullableInt:int32 = null;
-                arrayVector:[int32] (vectortype:""Array"");
-                memoryVector:[ubyte] (vectorType:""Memory"");
-                listVector:[int32] (vectorType:""IList"");
+                arrayVector:[int32] ({MetdataKeys.VectorKind}:""Array"");
+                memoryVector:[ubyte] ({MetdataKeys.VectorKind}:""Memory"");
+                listVector:[int32] ({MetdataKeys.VectorKind}:""IList"");
                 nestedTable:InnerTable;
-            }
+            }}
 
-            table InnerTable { str:string; }
+            table InnerTable {{ str:string; }}
 
-            struct Foo {
+            struct Foo {{
               id:ulong;
               count:short;
               prefix:byte;
               length:uint;
-            }";
+            }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(
                 schema, 

--- a/src/FlatSharpTests/FlatSharpCompiler/OptionalScalarTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/OptionalScalarTests.cs
@@ -30,16 +30,16 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void TestOptionalScalars()
         {
-            string schema = @"
+            string schema = $@"
             namespace OptionalScalarTests;
             
             enum TestEnum : ubyte
-            {
+            {{
                 A = 1,
                 B = 2
-            }
+            }}
 
-            table Table (PrecompiledSerializer:greedy) {
+            table Table ({MetdataKeys.SerializerKind}:greedy) {{
                 Bool : bool = null;
                 Byte : ubyte = null;
                 SByte : byte = null;
@@ -52,7 +52,7 @@ namespace FlatSharpTests.Compiler
                 Double : double = null;
                 Float : float32 = null;
                 Enum : TestEnum = null;
-            }";
+            }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
 

--- a/src/FlatSharpTests/FlatSharpCompiler/PrecompiledSerializerTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/PrecompiledSerializerTests.cs
@@ -32,35 +32,35 @@ namespace FlatSharpTests.Compiler
         public void MonsterTest()
         {
             // https://github.com/google/flatbuffers/blob/master/samples/monster.fbs
-            string schema = @"
+            string schema = $@"
 namespace MyGame;
-enum Color:byte { Red = 0, Green, Blue = 2 }
+enum Color:byte {{ Red = 0, Green, Blue = 2 }}
 
-union Equipment { Weapon, Vec3 } // Optionally add more tables.
+union Equipment {{ Weapon, Vec3 }} // Optionally add more tables.
 
-struct Vec3 {
+struct Vec3 {{
   x:float;
   y:float;
   z:float;
-}
+}}
 
-table Monster (PrecompiledSerializer:""greedymutable"") {
+table Monster ({MetdataKeys.SerializerKind}:""greedymutable"") {{
   pos:Vec3;
   mana:short = 150;
   hp:short = 100;
   name:string;
-  friendly:bool = false (deprecated);
+  friendly:bool = false ({MetdataKeys.Deprecated});
   inventory:[ubyte];
   color:Color = Blue;
   weapons:[Weapon];
   equipped:Equipment;
   path:[Vec3];
-}
+}}
 
-table Weapon (PrecompiledSerializer:lazy) {
+table Weapon ({MetdataKeys.SerializerKind}:lazy) {{
   name:string;
   damage:short;
-}
+}}
 
 root_type Monster;"; 
 
@@ -101,63 +101,63 @@ root_type Monster;";
         [TestMethod]
         public void FlagsOptions_Greedy()
         {
-            this.TestFlags(FlatBufferDeserializationOption.Greedy, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.Greedy)}");
+            this.TestFlags(FlatBufferDeserializationOption.Greedy, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.Greedy)}");
         }
 
         [TestMethod]
         public void FlagsOptions_MutableGreedy()
         {
-            this.TestFlags(FlatBufferDeserializationOption.GreedyMutable, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.GreedyMutable)}");
+            this.TestFlags(FlatBufferDeserializationOption.GreedyMutable, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.GreedyMutable)}");
         }
 
         [TestMethod]
         public void FlagsOptions_Default()
         {
-            this.TestFlags(FlatBufferDeserializationOption.Default, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.Default)}");
+            this.TestFlags(FlatBufferDeserializationOption.Default, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.Default)}");
         }
 
         [TestMethod]
         public void FlagsOptions_Default_Implicit()
         {
-            this.TestFlags(FlatBufferDeserializationOption.Default, $"PrecompiledSerializer");
+            this.TestFlags(FlatBufferDeserializationOption.Default, $"{MetdataKeys.SerializerKind}");
         }
 
         [TestMethod]
         public void FlagsOptions_Lazy()
         {
-            this.TestFlags(FlatBufferDeserializationOption.Lazy, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.Lazy)}");
+            this.TestFlags(FlatBufferDeserializationOption.Lazy, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.Lazy)}");
         }
 
         [TestMethod]
         public void FlagsOptions_MutableVectorCache()
         {
-            this.TestFlags(FlatBufferDeserializationOption.VectorCacheMutable, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.VectorCacheMutable)}");
+            this.TestFlags(FlatBufferDeserializationOption.VectorCacheMutable, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.VectorCacheMutable)}");
         }
 
         [TestMethod]
         public void FlagsOptions_VectorCache()
         {
-            this.TestFlags(FlatBufferDeserializationOption.VectorCache, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.VectorCache)}");
+            this.TestFlags(FlatBufferDeserializationOption.VectorCache, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.VectorCache)}");
         }
 
         [TestMethod]
         public void FlagsOptions_PropertyCache()
         {
-            this.TestFlags(FlatBufferDeserializationOption.PropertyCache, $"PrecompiledSerializer:{nameof(FlatBufferDeserializationOption.PropertyCache)}");
+            this.TestFlags(FlatBufferDeserializationOption.PropertyCache, $"{MetdataKeys.SerializerKind}:{nameof(FlatBufferDeserializationOption.PropertyCache)}");
         }
 
         [TestMethod]
         public void FlagsOptions_Invalid()
         {
-            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"PrecompiledSerializer:banana"));
-            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"PrecompiledSerializer:\"banana\""));
-            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"PrecompiledSerializer:\"greedy|banana\""));
-            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"PrecompiledSerializer:\"greedy|mutablegreedy\""));
+            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"{MetdataKeys.SerializerKind}:banana"));
+            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"{MetdataKeys.SerializerKind}:\"banana\""));
+            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"{MetdataKeys.SerializerKind}:\"greedy|banana\""));
+            Assert.ThrowsException<InvalidFbsFileException>(() => this.TestFlags(default, $"{MetdataKeys.SerializerKind}:\"greedy|mutablegreedy\""));
         }
 
         private void TestFlags(FlatBufferDeserializationOption expectedFlags, string metadata)
         {
-            string schema = $"namespace Test; table FooTable ({metadata}) {{ foo:string; bar:string (virtual:\"false\"); }}";
+            string schema = $"namespace Test; table FooTable ({metadata}) {{ foo:string; bar:string; }}";
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
 
             Type type = asm.GetType("Test.FooTable");

--- a/src/FlatSharpTests/FlatSharpCompiler/RealExamples.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/RealExamples.cs
@@ -86,24 +86,24 @@ struct Vec4 {{
   t:float;
 }}
 
-table Monster (PrecompiledSerializer:{flags}) {{
+table Monster ({MetdataKeys.SerializerKind}:{flags}) {{
   pos:Vec3;
   mana:short = 150;
   hp:short = 100;
   name:string;
-  friendly:bool = false (deprecated);
+  friendly:bool = false ({MetdataKeys.Deprecated});
   inventory:[ubyte];
   color:Color = Blue;
   weapons:[Weapon];
   equipped:Equipment;
   path:[Vec3];
   vec4:Vec4;
-  FakeVector1:[string] (VectorType:""IReadOnlyList"");
-  FakeVector2:[string] (VectorType:Array);
-  FakeVector3:[string] (VectorType:IList);
+  FakeVector1:[string] ({MetdataKeys.VectorKind}:""IReadOnlyList"");
+  FakeVector2:[string] ({MetdataKeys.VectorKind}:Array);
+  FakeVector3:[string] ({MetdataKeys.VectorKind}:IList);
   FakeVector4:[string];
-  FakeMemoryVector:[ubyte] (VectorType:Memory);
-  FakeMemoryVectorReadOnly:[ubyte] (VectorType:ReadOnlyMemory);
+  FakeMemoryVector:[ubyte] ({MetdataKeys.VectorKind}:Memory);
+  FakeMemoryVectorReadOnly:[ubyte] ({MetdataKeys.VectorKind}:ReadOnlyMemory);
 }}
 
 table Weapon {{

--- a/src/FlatSharpTests/FlatSharpCompiler/SharedStringCompilerTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/SharedStringCompilerTests.cs
@@ -30,13 +30,13 @@ namespace FlatSharpTests.Compiler
         [TestMethod, Ignore]
         public void SharedStringInlineTypeTest()
         {
-            string schema = @"
+            string schema = $@"
             namespace SharedStringTests;
-            table Table {
+            table Table {{
                 foo:SharedString;
-                bar:[SharedString] (VectorType:array);
-                baz:[SharedString] (VectorType:ilist);
-            }"; 
+                bar:[SharedString] ({MetdataKeys.VectorKind}:array);
+                baz:[SharedString] ({MetdataKeys.VectorKindLegacy}:ilist);
+            }}"; 
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
 
@@ -51,13 +51,13 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void SharedStringMetadataTypeTest()
         {
-            string schema = @"
+            string schema = $@"
             namespace SharedStringTests;
-            table Table {
-                foo:string (sharedstring);
-                bar:[string] (VectorType:array, sharedstring);
-                baz:[string] (VectorType:ilist, sharedstring);
-            }";
+            table Table {{
+                foo:string ({MetdataKeys.SharedString});
+                bar:[string] ({MetdataKeys.VectorKind}:array, {MetdataKeys.SharedString});
+                baz:[string] ({MetdataKeys.VectorKind}:ilist, {MetdataKeys.SharedStringLegacy});
+            }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
 

--- a/src/FlatSharpTests/FlatSharpCompiler/SortedVectors.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/SortedVectors.cs
@@ -33,15 +33,15 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void SortedVector_StringKey()
         {
-            string schema = @"
-table Monster (PrecompiledSerializer) {
-  Vector:[VectorMember] (VectorType:IReadOnlyList, SortedVector);
-}
+            string schema = $@"
+table Monster ({MetdataKeys.SerializerKind}) {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IReadOnlyList, {MetdataKeys.SortedVector});
+}}
 
-table VectorMember {
-    Key:string (key);
+table VectorMember {{
+    Key:string ({MetdataKeys.Key});
     Data:int32;
-}
+}}
 "; 
             // We are just verifying that the schema can be generated and compiled. The testing of the logic portion of the sorted vector code takes
             // place elsewhere.
@@ -63,15 +63,15 @@ table VectorMember {
         [TestMethod]
         public void SortedVector_IntKey()
         {
-            string schema = @"
-table Monster (PrecompiledSerializer) {
-  Vector:[VectorMember] (VectorType:IReadOnlyList, SortedVector);
-}
+            string schema = $@"
+table Monster ({MetdataKeys.SerializerKind}) {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IReadOnlyList, {MetdataKeys.SortedVector});
+}}
 
-table VectorMember {
+table VectorMember {{
     Data:string;
     Key:int32 (Key);
-}
+}}
 ";
             // We are just verifying that the schema can be generated and compiled. The testing of the logic portion of the sorted vector code takes
             // place elsewhere.
@@ -97,24 +97,24 @@ table VectorMember {
         [TestMethod]
         public void SortedVector_InvalidKeys_NoSerializer()
         {
-            string schema = @"
-enum TestEnum : ubyte { One = 1, Two = 2 }
+            string schema = $@"
+enum TestEnum : ubyte {{ One = 1, Two = 2 }}
 
-union TestUnion { VectorMember }
+union TestUnion {{ VectorMember }}
 
-table Monster {
-  Vector:[VectorMember] (VectorType:IReadOnlyList, SortedVector);
-}
-struct FakeStruct { StructData:int32; }
+table Monster {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IReadOnlyList, {MetdataKeys.SortedVector});
+}}
+struct FakeStruct {{ StructData:int32; }}
 
-table VectorMember {
-    Data:string (Key);
+table VectorMember {{
+    Data:string ({MetdataKeys.Key});
     Key:int32;
     Enum:TestEnum;
     Struct:FakeStruct;
     Union:TestUnion;
     StructVector:[FakeStruct];
-}
+}}
 
 ";
             // We are just verifying that the schema can be generated and compiled. The testing of the logic portion of the sorted vector code takes
@@ -147,31 +147,31 @@ table VectorMember {
         [TestMethod]
         public void SortedVector_InvalidKeys_WithSerializer()
         {
-            string schema = @"
-enum TestEnum : ubyte { One = 1, Two = 2 }
+            string schema = $@"
+enum TestEnum : ubyte {{ One = 1, Two = 2 }}
 
-union TestUnion { VectorMember }
+union TestUnion {{ VectorMember }}
 
-table Monster (PrecompiledSerializer) {
-  Vector:[VectorMember] (VectorType:IReadOnlyList, SortedVector, Key);
-}
-struct FakeStruct { Data:int32 (key); }
+table Monster ({MetdataKeys.SerializerKind}) {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IReadOnlyList, {MetdataKeys.SortedVector}, {MetdataKeys.Key});
+}}
+struct FakeStruct {{ Data:int32 ({MetdataKeys.Key}); }}
 
-table VectorMember {
-    Data:string (SortedVector, Key);
-    Key:int32 (SortedVector, Key);
-    Enum:TestEnum (SortedVector, Key);
-    Struct:FakeStruct (SortedVector, key);
-    Union:TestUnion (SortedVector, Key);
-    StructVector:[FakeStruct] (SortedVector, key);
-}
+table VectorMember {{
+    Data:string ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+    Key:int32 ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+    Enum:TestEnum ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+    Struct:FakeStruct ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+    Union:TestUnion ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+    StructVector:[FakeStruct] ({MetdataKeys.SortedVector}, {MetdataKeys.Key});
+}}
 
 ";
             Assert.ThrowsException<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
         }
 
         [TestMethod]
-        public void SortedVector_IndexedVector_KeyTypesCorrect_SharedString() => this.SortedVector_IndexedVector_KeyTypesCorrect<SharedString>("string", "SharedString");
+        public void SortedVector_IndexedVector_KeyTypesCorrect_SharedString() => this.SortedVector_IndexedVector_KeyTypesCorrect<SharedString>("string", MetdataKeys.SharedString);
 
         [TestMethod]
         public void SortedVector_IndexedVector_KeyTypesCorrect_String() => this.SortedVector_IndexedVector_KeyTypesCorrect<string>("string");
@@ -213,8 +213,8 @@ table VectorMember {
         public void SortedVector_IndexedVector_NoKey()
         {
             string schema = $@"
-table Monster (PrecompiledSerializer) {{
-  Vector:[VectorMember] (VectorType:IIndexedVector);
+table Monster ({MetdataKeys.SerializerKind}) {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IIndexedVector);
 }}
 table VectorMember {{
     Data:string;
@@ -225,11 +225,11 @@ table VectorMember {{
         private void SortedVector_IndexedVector_KeyTypesCorrect<TKeyType>(string type, string metadata = null)
         {
             string schema = $@"
-table Monster (PrecompiledSerializer) {{
-  Vector:[VectorMember] (VectorType:IIndexedVector);
+table Monster ({MetdataKeys.SerializerKind}) {{
+  Vector:[VectorMember] ({MetdataKeys.VectorKind}:IIndexedVector);
 }}
 table VectorMember {{
-    Data:{type} (Key {(!string.IsNullOrEmpty(metadata) ? ", " : "")}{metadata});
+    Data:{type} ({MetdataKeys.Key} {(!string.IsNullOrEmpty(metadata) ? ", " : "")}{metadata});
 }}";
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
             var monsterType = asm.GetTypes().Single(t => t.Name == "Monster");

--- a/src/FlatSharpTests/FlatSharpCompiler/StructVectorTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/StructVectorTests.cs
@@ -78,12 +78,12 @@ namespace FlatSharpTests.Compiler
             string schema = $@"
             namespace StructVectorTests;
 
-            table Table (PrecompiledSerializer) {{
+            table Table ({MetdataKeys.SerializerKind}) {{
                 foo:Foo;
             }}
             struct Bar {{ A:ubyte; B:ulong; }}
             struct Foo {{
-              V:[Bar:{length}] (nonVirtual);
+              V:[Bar:{length}] ({MetdataKeys.NonVirtualProperty});
             }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(
@@ -136,7 +136,7 @@ namespace FlatSharpTests.Compiler
             string schema = $@"
             namespace StructVectorTests;
 
-            table Table (PrecompiledSerializer) {{
+            table Table ({MetdataKeys.SerializerKind}) {{
                 foo:Foo;
             }}
             struct Foo {{

--- a/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
@@ -201,21 +201,21 @@ namespace FlatSharpTests.Compiler
         private void RunCompoundTest<T>(string fbsType)
         {
             this.RunSingleTest<T>(fbsType);
-            this.RunSingleTest<T>($"{fbsType} (deprecated)", deprecated: true);
+            this.RunSingleTest<T>($"{fbsType} ({MetdataKeys.Deprecated})", deprecated: true);
             this.RunSingleTest<IList<T>>($"[{fbsType}]");
-            this.RunSingleTest<IList<T>>($"[{fbsType}]  (vectortype: IList)");
-            this.RunSingleTest<T[]>($"[{fbsType}]  (vectortype: Array)");
-            this.RunSingleTest<IReadOnlyList<T>>($"[{fbsType}]  (vectortype: IReadOnlyList)");
+            this.RunSingleTest<IList<T>>($"[{fbsType}]  ({MetdataKeys.VectorKind}: IList)");
+            this.RunSingleTest<T[]>($"[{fbsType}]  ({MetdataKeys.VectorKind}: Array)");
+            this.RunSingleTest<IReadOnlyList<T>>($"[{fbsType}]  ({MetdataKeys.VectorKind}: IReadOnlyList)");
 
             if (typeof(T) == typeof(byte))
             {
-                this.RunSingleTest<Memory<T>?>($"[{fbsType}]  (vectortype: Memory)");
-                this.RunSingleTest<ReadOnlyMemory<T>?>($"[{fbsType}]  (vectortype: ReadOnlyMemory)");
+                this.RunSingleTest<Memory<T>?>($"[{fbsType}]  ({MetdataKeys.VectorKind}: Memory)");
+                this.RunSingleTest<ReadOnlyMemory<T>?>($"[{fbsType}]  ({MetdataKeys.VectorKind}: ReadOnlyMemory)");
             }
             else
             {
-                Assert.ThrowsException<InvalidFbsFileException>(() => this.RunSingleTest<Memory<T>>($"[{fbsType}]  (vectortype: Memory)"));
-                Assert.ThrowsException<InvalidFbsFileException>(() => this.RunSingleTest<ReadOnlyMemory<T>>($"[{fbsType}]  (vectortype: ReadOnlyMemory)"));
+                Assert.ThrowsException<InvalidFbsFileException>(() => this.RunSingleTest<Memory<T>>($"[{fbsType}]  ({MetdataKeys.VectorKind}: Memory)"));
+                Assert.ThrowsException<InvalidFbsFileException>(() => this.RunSingleTest<ReadOnlyMemory<T>>($"[{fbsType}]  ({MetdataKeys.VectorKind}: ReadOnlyMemory)"));
             }
         }
 

--- a/src/FlatSharpTests/FlatSharpCompiler/UnionTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/UnionTests.cs
@@ -29,19 +29,19 @@ namespace FlatSharpTests.Compiler
         [TestMethod]
         public void TestUnionCustomClassGeneration()
         {
-            const string Schema = @"
+            string schema = $@"
 namespace Foobar;
 
-table A { Value:int32; }
-table B { Value:int32; }
-struct C { Value:int32; }
+table A {{ Value:int32; }}
+table B {{ Value:int32; }}
+struct C {{ Value:int32; }}
 
-union TestUnion { First:A, B, Foobar.C }
+union TestUnion {{ First:A, B, Foobar.C }}
 
-table D (PrecompiledSerializer) { Union:TestUnion; }
+table D ({MetdataKeys.SerializerKind}) {{ Union:TestUnion; }}
 
 ";
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(Schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
             Type unionType = asm.GetType("Foobar.TestUnion");
             Type aType = asm.GetType("Foobar.A");
             Type bType = asm.GetType("Foobar.B");
@@ -110,20 +110,20 @@ table D (PrecompiledSerializer) { Union:TestUnion; }
         [TestMethod]
         public void TestUnionWithStringGeneration()
         {
-            const string Schema = @"
+            string schema = $@"
 namespace Foobar;
 
-table A { Value:int32; }
-table B { Value:int32; }
-struct C { Value:int32; }
+table A {{ Value:int32; }}
+table B {{ Value:int32; }}
+struct C {{ Value:int32; }}
 
-union TestUnion { First:A, B, Foobar.C, string }
+union TestUnion {{ First:A, B, Foobar.C, string }}
 
-table D (PrecompiledSerializer) { Union:TestUnion; }
+table D ({MetdataKeys.SerializerKind}) {{ Union:TestUnion; }}
 
 ";
             // Simply ensure that the union is generated as FlatBufferUnion and no custom class is created.
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(Schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
             Type unionType = asm.GetType("Foobar.TestUnion");
 
             Type dType = asm.GetType("Foobar.D");
@@ -134,20 +134,20 @@ table D (PrecompiledSerializer) { Union:TestUnion; }
         [TestMethod]
         public void TestUnionWithAliasedStringGeneration()
         {
-            const string Schema = @"
+            string schema = $@"
 namespace Foobar;
 
-table A { Value:int32; }
-table B { Value:int32; }
-struct C { Value:int32; }
+table A {{ Value:int32; }}
+table B {{ Value:int32; }}
+struct C {{ Value:int32; }}
 
-union TestUnion { First:A, B, Foobar.C, StringAlias:string }
+union TestUnion {{ First:A, B, Foobar.C, StringAlias:string }}
 
-table D (PrecompiledSerializer) { Union:TestUnion; }
+table D ({MetdataKeys.SerializerKind}) {{ Union:TestUnion; }}
 
 ";
             // Simply ensure that the union is generated as FlatBufferUnion and no custom class is created.
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(Schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
             Type unionType = asm.GetType("Foobar.TestUnion");
             Type dType = asm.GetType("Foobar.D");
 

--- a/src/FlatSharpTests/FlatSharpCompiler/VirtualMemberTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/VirtualMemberTests.cs
@@ -36,20 +36,20 @@ namespace FlatSharpTests.Compiler
         {
             string schema = $@"
             namespace VirtualTests;
-            table VirtualTable (nonVirtual:""{defaultNonVirtual.ToString().ToLowerInvariant()}"", PrecompiledSerializer:Lazy) {{
+            table VirtualTable ({MetdataKeys.NonVirtualProperty}:""{defaultNonVirtual.ToString().ToLowerInvariant()}"", PrecompiledSerializer:Lazy) {{
                 Default:int;
-                ForcedVirtual:int (nonVirtual:""false"");
-                ForcedNonVirtual:int (nonVirtual:""true"");
+                ForcedVirtual:int ({MetdataKeys.NonVirtualProperty}:""false"");
+                ForcedNonVirtual:int ({MetdataKeys.NonVirtualProperty}:""true"");
                 Struct:VirtualStruct;
             }}
 
-            struct VirtualStruct (nonVirtual:""{defaultNonVirtual.ToString().ToLowerInvariant()}"") {{
+            struct VirtualStruct ({MetdataKeys.NonVirtualProperty}:""{defaultNonVirtual.ToString().ToLowerInvariant()}"") {{
                 Default:int;
-                ForcedVirtual:int (nonVirtual:""false"");
-                ForcedNonVirtual:int (nonVirtual:""true"");
+                ForcedVirtual:int ({MetdataKeys.NonVirtualProperty}:""false"");
+                ForcedNonVirtual:int ({MetdataKeys.NonVirtualProperty}:""true"");
             }}
 
-            table DefaultTable (PrecompiledSerializer:lazy) {{ Default:int; Struct:DefaultStruct; }}
+            table DefaultTable ({MetdataKeys.SerializerKind}:lazy) {{ Default:int; Struct:DefaultStruct; }}
             struct DefaultStruct {{ Default:int; }}";
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());


### PR DESCRIPTION
Add namespaced compiler attributes that are preferred over the legacy ones, update tests to use the new attributes. Pull attribute names into a file instead of scattering them around.