### PR TITLE
Optimize Reads for single-width fields

### DIFF
--- a/src/Benchmark/FBBench/FBBenchCore.cs
+++ b/src/Benchmark/FBBench/FBBenchCore.cs
@@ -30,7 +30,6 @@ namespace Benchmark.FBBench
 
     using JobKind = BenchmarkDotNet.Attributes.MediumRunJobAttribute;
 
-    [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp31)]
     [JobKind(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp50)]
     [CsvExporter(BenchmarkDotNet.Exporters.Csv.CsvSeparator.Comma)]
     public abstract class FBBenchCore

--- a/src/Benchmark/Internal/SerializationContextBenchmark.cs
+++ b/src/Benchmark/Internal/SerializationContextBenchmark.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * Copyright 2018 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Benchmark
+{
+    using BenchmarkDotNet.Attributes;
+    using FlatSharp;
+    using System;
+    using System.Collections.Generic;
+
+    [ShortRunJob(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp50)]
+    [CsvExporter(BenchmarkDotNet.Exporters.Csv.CsvSeparator.Comma)]
+    public class SerializationContextBenchmark
+    {
+        private static readonly SerializationContext context = new SerializationContext();
+
+        private const int ScratchLength = 10 * 1024 * 1024;
+        private readonly byte[] Scratch = new byte[ScratchLength];
+
+        [Params(4, 8, 32, 64)]
+        public int VTableLength { get; set; }
+
+        [Params(10, 100, 200, 400)]
+        public int VTableCount { get; set; }
+
+        // random.
+        private byte[][] RandomVTables;
+
+        // non random with repeated elements.
+        private byte[][] GuassianVTables;
+
+        private byte[] ZeroByteVTable;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.ZeroByteVTable = new byte[this.VTableLength];
+
+            Random r = new Random();
+
+            List<byte[]> allVtables = new List<byte[]>();
+            for (int i = 0; i < 2 * this.VTableCount; ++i)
+            {
+                byte[] vtable = new byte[this.VTableLength];
+                r.NextBytes(vtable);
+                allVtables.Add(vtable);
+            }
+
+            this.RandomVTables = new byte[this.VTableCount][];
+            this.GuassianVTables = new byte[this.VTableCount][];
+
+            for (int i = 0; i < this.VTableCount; ++i)
+            {
+                this.RandomVTables[i] = allVtables[i];
+                this.GuassianVTables[i] = allVtables[i % ((int)Math.Sqrt(this.VTableCount))];
+            }
+
+            for (int i = 0; i < this.VTableCount / 2; ++i)
+            {
+                this.GuassianVTables[r.Next(this.VTableCount)] = allVtables[r.Next(this.VTableCount)];
+            }
+        }
+
+        [Benchmark]
+        public int FinishVTable_Zero()
+        {
+            context.Reset(ScratchLength);
+            return context.FinishVTable(default(SpanWriter), 30, Scratch, ZeroByteVTable);
+        }
+
+        [Benchmark]
+        public void FinishVTables_Random()
+        {
+            context.Reset(ScratchLength);
+
+            var random = this.RandomVTables;
+            for (int i = 0; i < random.Length; ++i)
+            {
+                context.FinishVTable(default(SpanWriter), 30, Scratch, random[i]);
+            }
+        }
+
+        [Benchmark]
+        public void FinishVTables_Guassian()
+        {
+            context.Reset(ScratchLength);
+
+            var random = this.GuassianVTables;
+            for (int i = 0; i < random.Length; ++i)
+            {
+                context.FinishVTable(default(SpanWriter), 30, Scratch, random[i]);
+            }
+        }
+    }
+}

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -37,6 +37,9 @@ namespace Benchmark
 #if !NO_SHARED_STRINGS
             summaries.Add(BenchmarkRunner.Run<FBBench.FBSharedStringBench>());
 #endif
+#if CURRENT_VERSION_ONLY
+            summaries.Add(BenchmarkRunner.Run<SerializationContextBenchmark>());
+#endif
 
             foreach (var item in summaries)
             {

--- a/src/FlatSharp.Runtime/IO/InputBufferExtensions.cs
+++ b/src/FlatSharp.Runtime/IO/InputBufferExtensions.cs
@@ -163,35 +163,6 @@ namespace FlatSharp
             }
         }
 
-        /// <summary>
-        /// Traverses a vtable to find the absolute offset of a table field.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetAbsoluteTableFieldLocation<TBuffer>(
-            this TBuffer buffer, 
-            int tableOffset,
-            int index, 
-            int vtableOffset, 
-            int maxIndex) where TBuffer : IInputBuffer
-        {
-            checked
-            {
-                if (index > maxIndex)
-                {
-                    // Not present, return 0. 0 is an indication that that field is not present.
-                    return 0;
-                }
-
-                ushort relativeOffset = buffer.ReadUShort(vtableOffset + (2 * (2 + index)));
-                if (relativeOffset == 0)
-                {
-                    return 0;
-                }
-
-                return tableOffset + relativeOffset;
-            }
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidVtableException()
         {

--- a/src/FlatSharp.Runtime/SerializationHelpers.cs
+++ b/src/FlatSharp.Runtime/SerializationHelpers.cs
@@ -71,7 +71,7 @@ namespace FlatSharp
         public static int GetAlignmentError(int offset, int alignment)
         {
             Debug.Assert(alignment == 1 || alignment % 2 == 0);
-            return (~offset + 1) & (alignment - 1);
+            return (-offset) & (alignment - 1);
         }
 
         /// <summary>

--- a/src/FlatSharp/TypeModel/StructTypeModel.cs
+++ b/src/FlatSharp/TypeModel/StructTypeModel.cs
@@ -130,7 +130,7 @@ $@"
 
                 classDefinition = CSharpHelpers.CreateDeserializeClass(
                     className,
-                    this.ClrType,
+                    this,
                     propertyOverrides,
                     context.Options);
             }

--- a/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
+++ b/src/FlatSharpTests/FlatSharpCompiler/TableMemberTests.cs
@@ -76,10 +76,10 @@ namespace FlatSharpTests.Compiler
         public void TableMember_ulong() => this.RunCompoundTestWithDefaultValue<ulong>("uint64");
 
         [TestMethod]
-        public void TableMember_float_alias() => this.RunCompoundTestWithDefaultValue<float>("float", "G17");
+        public void TableMember_float_alias() => this.RunCompoundTestWithDefaultValue<float>("float", "G3", 3.14f);
 
         [TestMethod]
-        public void TableMember_float() => this.RunCompoundTestWithDefaultValue<float>("float32", "G17");
+        public void TableMember_float() => this.RunCompoundTestWithDefaultValue<float>("float32", "G3", 3.14f);
 
         [TestMethod]
         public void TableMember_double_alias() => this.RunCompoundTestWithDefaultValue<double>("double", "G17");
@@ -186,15 +186,22 @@ namespace FlatSharpTests.Compiler
             this.RunCompoundTest<bool>(fbsType);
         }
 
-        private void RunCompoundTestWithDefaultValue<T>(string fbsType, string format = null) where T : struct, IFormattable
+        private void RunCompoundTestWithDefaultValue<T>(string fbsType, string format = null, T? value = null) where T : struct, IFormattable
         {
-            Random random = new Random();
-            byte[] data = new byte[16];
-            random.NextBytes(data);
-            T randomValue = MemoryMarshal.Cast<byte, T>(data)[0];
+            T randomValue;
+            if (value is null)
+            {
+                Random random = new Random();
+                byte[] data = new byte[16];
+                random.NextBytes(data);
+                randomValue = MemoryMarshal.Cast<byte, T>(data)[0];
+            }
+            else
+            {
+                randomValue = value.Value;
+            }
 
             this.RunSingleTest<T>($"{fbsType} = {randomValue.ToString(format, null).ToLowerInvariant()}", hasDefaultValue: true, expectedDefaultValue: randomValue);
-
             this.RunCompoundTest<T>(fbsType);
         }
 

--- a/src/runbenchmarks.cmd
+++ b/src/runbenchmarks.cmd
@@ -1,0 +1,21 @@
+dotnet build -c release
+
+pushd Benchmark\bin\release\net5.0
+Benchmark.exe
+popd
+
+pushd Benchmark.4.0.0\bin\release\net5.0
+Benchmark.4.0.0.exe
+popd
+
+pushd Benchmark.3.3.0\bin\release\net5.0
+Benchmark.3.3.0.exe
+popd
+
+pushd Benchmark.3.2.0\bin\release\net5.0
+Benchmark.3.2.0.exe
+popd
+
+pushd Benchmark.3.0.0\bin\release\net5.0
+Benchmark.3.0.0.exe
+popd


### PR DESCRIPTION
Remove an if statement and a couple of vtable reads from the hot path for single-width vtable fields. Up to ~10% speed improvement depending on scenario. 8 bytes extra memory allocated on deserialized tables. Probably worth it.