### PR TITLE
Struct Vectors Expose Protected Properties

### DIFF
--- a/src/FlatSharp.Compiler/CodeWriter.cs
+++ b/src/FlatSharp.Compiler/CodeWriter.cs
@@ -40,6 +40,13 @@ namespace FlatSharp.Compiler
             this.builder.AppendLine(line);
         }
 
+        public void AppendMethodSummaryComment(string comment)
+        {
+            this.AppendLine("/// <summary>");
+            this.AppendLine($"/// {comment}");
+            this.AppendLine("/// </summary>");
+        }
+
         public void AppendLine()
         {
             for (int i = 0; i < this.indent; ++i)

--- a/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
@@ -155,9 +155,9 @@ namespace FlatSharp.Compiler
             writer.AppendLine($"}}");
         }
 
-        public string ResolveTypeName(string fbsFieldType, CompileContext context)
+        public string ResolveTypeName(string fbsFieldType, CompileContext context, out ITypeModel? resolvedTypeModel)
         {
-            if (context.TypeModelContainer.TryResolveFbsAlias(fbsFieldType, out ITypeModel? resolvedTypeModel))
+            if (context.TypeModelContainer.TryResolveFbsAlias(fbsFieldType, out resolvedTypeModel))
             {
                 fbsFieldType = resolvedTypeModel.ClrType.FullName ?? throw new InvalidOperationException("Full name was null");
             }

--- a/src/FlatSharp.Compiler/Visitors/FieldVisitor.cs
+++ b/src/FlatSharp.Compiler/Visitors/FieldVisitor.cs
@@ -87,7 +87,14 @@ namespace FlatSharp.Compiler
                     for (int i = 0; i < structVectorLength.Value; ++i)
                     {
                         string name = $"__flatsharp__{definition.Name}_{i}";
-                        this.parent.Fields.Add(definition with { Name = name, SetterKind = SetterKind.Public, IsHidden = true });
+                        this.parent.Fields.Add(definition with
+                        {
+                            Name = name,
+                            SetterKind = SetterKind.Protected,
+                            GetterModifier = AccessModifier.Protected,
+                            CustomGetter = $"{definition.Name}[{i}]"
+                        });
+
                         groupNames.Add(name);
                     }
 

--- a/src/FlatSharp.Runtime/Attributes/FlatBufferItemAttribute.cs
+++ b/src/FlatSharp.Runtime/Attributes/FlatBufferItemAttribute.cs
@@ -17,6 +17,7 @@
 namespace FlatSharp.Attributes
 {
     using System;
+    using System.ComponentModel;
 
     /// <summary>
     /// Defines a member of a FlatBuffer struct or table.
@@ -65,5 +66,12 @@ namespace FlatSharp.Attributes
         /// is set in a context where Force-Writing is not allowed.
         /// </summary>
         public bool ForceWrite { get; set; }
+
+        /// <summary>
+        /// A C# expression that gets the value of the current property from the enclosing object.
+        /// This is a very advanced feature and is only intended to be used by the FlatSharp compiler.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string CustomGetter { get; set; }
     }
 }

--- a/src/FlatSharp/Serialization/AccessModifier.cs
+++ b/src/FlatSharp/Serialization/AccessModifier.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright 2020 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace FlatSharp
+{
+    /// <summary>
+    /// Defines access modifiers
+    /// </summary>
+    public enum AccessModifier
+    {
+        /// <summary>
+        /// A public setter.
+        /// </summary>
+        Public = 0,
+
+        /// <summary>
+        /// A protected internal setter.
+        /// </summary>
+        ProtectedInternal = 1,
+
+        /// <summary>
+        /// A protected setter.
+        /// </summary>
+        Protected = 2,
+    }
+}

--- a/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
+++ b/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
@@ -207,14 +207,14 @@ namespace FlatSharp
                     setterBody = $"this.{GetFieldName(itemModel)} = value; this.{GetHasValueFieldName(itemModel)} = true;";
                 }
 
-                setter = $"{accessModifiers.setModifier} {verb} {{ {setterBody} }}";
+                setter = $"{accessModifiers.setModifier.ToCSharpString()} {verb} {{ {setterBody} }}";
             }
 
             string typeName = itemModel.ItemTypeModel.GetNullableAnnotationTypeName(this.typeModel.SchemaType);
             this.propertyOverrides.Add($@"
-                {accessModifiers.propertyModifier} override {typeName} {itemModel.PropertyInfo.Name}
+                {accessModifiers.propertyModifier.ToCSharpString()} override {typeName} {itemModel.PropertyInfo.Name}
                 {{ 
-                    {accessModifiers.getModifer} get
+                    {accessModifiers.getModifer.ToCSharpString()} get
                     {{
                         {getterBody}
                     }}

--- a/src/FlatSharp/TypeModel/ITypeModel.cs
+++ b/src/FlatSharp/TypeModel/ITypeModel.cs
@@ -157,7 +157,7 @@ namespace FlatSharp.TypeModel
         /// the declared configuration in the table. This method will not be invoked
         /// when the type is serialized in other contexts, such as vectors and structs.
         /// </summary>
-        TableMemberModel AdjustTableMember(TableMemberModel source);
+        void AdjustTableMember(TableMemberModel source);
 
         /// <summary>
         /// Initializes and validates the type model.

--- a/src/FlatSharp/TypeModel/IndexedVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/IndexedVectorTypeModel.cs
@@ -82,18 +82,10 @@ namespace FlatSharp.TypeModel
             }
         }
 
-        public override TableMemberModel AdjustTableMember(TableMemberModel source)
+        public override void AdjustTableMember(TableMemberModel source)
         {
             // Force the vector to be sorted.
-            return new TableMemberModel(
-                source.ItemTypeModel,
-                source.PropertyInfo,
-                source.Index,
-                source.DefaultValue,
-                isSortedVector: true,
-                source.IsKey,
-                source.IsDeprecated,
-                source.ForceWrite);
+            source.IsSortedVector = true;
         }
 
         public override CodeGeneratedMethod CreateParseMethodBody(ParserCodeGenContext context)

--- a/src/FlatSharp/TypeModel/RuntimeTypeModel.cs
+++ b/src/FlatSharp/TypeModel/RuntimeTypeModel.cs
@@ -154,9 +154,8 @@ namespace FlatSharp.TypeModel
             return false;
         }
 
-        public virtual TableMemberModel AdjustTableMember(TableMemberModel source)
+        public virtual void AdjustTableMember(TableMemberModel source)
         {
-            return source;
         }
 
         public IEnumerable<Type> GetReferencedTypes()

--- a/src/FlatSharp/TypeModel/StructMemberModel.cs
+++ b/src/FlatSharp/TypeModel/StructMemberModel.cs
@@ -16,6 +16,7 @@
  
  namespace FlatSharp.TypeModel
 {
+    using FlatSharp.Attributes;
     using System;
     using System.Reflection;
 
@@ -27,9 +28,9 @@
         public StructMemberModel(
             ITypeModel propertyModel,
             PropertyInfo propertyInfo,
-            ushort index,
+            FlatBufferItemAttribute attribute,
             int offset,
-            int length) : base(propertyModel, propertyInfo, index)
+            int length) : base(propertyModel, propertyInfo, attribute)
         {
             this.Offset = offset;
             this.Length = length;

--- a/src/FlatSharp/TypeModel/StructTypeModel.cs
+++ b/src/FlatSharp/TypeModel/StructTypeModel.cs
@@ -132,6 +132,10 @@ namespace FlatSharp.TypeModel
                 var memberInfo = this.Members[i];
 
                 string propertyAccessor = $"{context.ValueVariableName}.{memberInfo.PropertyInfo.Name}";
+                if (memberInfo.CustomGetter is not null)
+                {
+                    propertyAccessor = $"{context.ValueVariableName}.{memberInfo.CustomGetter}";
+                }
 
                 var propContext = context.With(
                     offsetVariableName: $"({memberInfo.Offset} + {context.OffsetVariableName})",
@@ -242,7 +246,7 @@ namespace FlatSharp.TypeModel
                 StructMemberModel model = new StructMemberModel(
                     propertyModel,
                     property,
-                    index,
+                    item.Attribute,
                     this.inlineSize,
                     length);
 

--- a/src/FlatSharp/TypeModel/TableMemberModel.cs
+++ b/src/FlatSharp/TypeModel/TableMemberModel.cs
@@ -19,6 +19,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using FlatSharp.Attributes;
 
     /// <summary>
     /// Describes a member of a FlatBuffer table.
@@ -28,18 +29,13 @@
         public TableMemberModel(
             ITypeModel propertyModel, 
             PropertyInfo propertyInfo, 
-            ushort index, 
-            object? defaultValue,
-            bool isSortedVector,
-            bool isKey,
-            bool isDeprecated,
-            bool forceWrite) : base(propertyModel, propertyInfo, index)
+            FlatBufferItemAttribute attribute) : base(propertyModel, propertyInfo, attribute)
         {
-            this.DefaultValue = defaultValue;
-            this.IsSortedVector = isSortedVector;
-            this.IsKey = isKey;
-            this.IsDeprecated = isDeprecated;
-            this.ForceWrite = forceWrite;
+            this.DefaultValue = attribute.DefaultValue;
+            this.IsSortedVector = attribute.SortedVector;
+            this.IsKey = attribute.Key;
+            this.IsDeprecated = attribute.Deprecated;
+            this.ForceWrite = attribute.ForceWrite;
 
             if (!propertyModel.IsValidTableMember)
             {
@@ -48,35 +44,35 @@
 
             if (this.DefaultValue is not null && !propertyModel.ValidateDefaultValue(this.DefaultValue))
             {
-                throw new InvalidFlatBufferDefinitionException($"Table property {propertyInfo.Name} declared default value of type {propertyModel.ClrType.Name}, but the value was of type {defaultValue?.GetType()?.Name}. Please ensure that the property is allowed to have a default value and that the types match.");
+                throw new InvalidFlatBufferDefinitionException($"Table property {propertyInfo.Name} declared default value of type {propertyModel.ClrType.Name}, but the value was of type {this.DefaultValue.GetType().GetCompilableTypeName()}. Please ensure that the property is allowed to have a default value and that the types match.");
             }
         }
         
         /// <summary>
         /// The default value of the table member.
         /// </summary>
-        public object? DefaultValue { get; }
+        public object? DefaultValue { get; set; }
 
         /// <summary>
         /// Indicates if the member vector should be sorted before serializing.
         /// </summary>
-        public bool IsSortedVector { get; }
+        public bool IsSortedVector { get; set; }
 
         /// <summary>
         /// Indicates that this property is the key for the table.
         /// </summary>
-        public bool IsKey { get; }
+        public bool IsKey { get; set; }
 
         /// <summary>
         /// Indicates that this property is deprecated and serializers need not be generated for it.
         /// </summary>
-        public bool IsDeprecated { get; }
+        public bool IsDeprecated { get; set; }
 
         /// <summary>
         /// Indicates that this field should always be written to a table, even
         /// if the default value matches.
         /// </summary>
-        public bool ForceWrite { get; }
+        public bool ForceWrite { get; set; }
 
         /// <summary>
         /// Returns a C# literal that is equal to the default value.

--- a/src/FlatSharp/TypeModel/TableTypeModel.cs
+++ b/src/FlatSharp/TypeModel/TableTypeModel.cs
@@ -163,14 +163,9 @@ namespace FlatSharp.TypeModel
                 TableMemberModel model = new TableMemberModel(
                     property.ItemTypeModel,
                     property.Property,
-                    index,
-                    property.Attribute.DefaultValue,
-                    property.Attribute.SortedVector,
-                    property.Attribute.Key,
-                    property.Attribute.Deprecated,
-                    property.Attribute.ForceWrite);
+                    property.Attribute);
 
-                model = property.ItemTypeModel.AdjustTableMember(model);
+                property.ItemTypeModel.AdjustTableMember(model);
 
                 if (property.Attribute.Key)
                 {
@@ -383,7 +378,13 @@ $@"
                 }
 
                 string valueName = $"index{index}Value";
-                getters.Add($"var {valueName} = {context.ValueVariableName}.{memberModel.PropertyInfo.Name};");
+                string getter = memberModel.PropertyInfo.Name;
+                if (!string.IsNullOrEmpty(memberModel.CustomGetter))
+                {
+                    getter = memberModel.CustomGetter;
+                }
+
+                getters.Add($"var {valueName} = {context.ValueVariableName}.{getter};");
                 
                 for (int i = 0; i < memberModel.ItemTypeModel.PhysicalLayout.Length; ++i)
                 {

--- a/src/FlatSharp/TypeModel/TypeFacadeTypeModelProvider.cs
+++ b/src/FlatSharp/TypeModel/TypeFacadeTypeModelProvider.cs
@@ -89,7 +89,7 @@ namespace FlatSharp.TypeModel
 
             public ConstructorInfo? PreferredSubclassConstructor => this.underlyingModel.PreferredSubclassConstructor;
 
-            public TableMemberModel AdjustTableMember(TableMemberModel source) => this.underlyingModel.AdjustTableMember(source);
+            public void AdjustTableMember(TableMemberModel source) => this.underlyingModel.AdjustTableMember(source);
 
             public CodeGeneratedMethod CreateGetMaxSizeMethodBody(GetMaxSizeCodeGenContext context)
             {


### PR DESCRIPTION
Use protected properties and a little magic to make struct vectors usable.