### PR TITLE
Add interface to tables with serializers

### DIFF
--- a/src/FlatSharp.Runtime/IFlatBufferSerializable.cs
+++ b/src/FlatSharp.Runtime/IFlatBufferSerializable.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * Copyright 2021 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace FlatSharp
+{
+    using System;
+
+    /// <summary>
+    /// An object that can supply an <see cref="ISerializer"/> instance that can serialize and parse it.
+    /// </summary>
+    public interface IFlatBufferSerializable
+    {
+        /// <summary>
+        /// Gets a <see cref="ISerializer"/> instance that can serialize this object.
+        /// </summary>
+        ISerializer Serializer { get; }
+    }
+
+    /// <summary>
+    /// An object that can supply an <see cref="ISerializer{T}"/> instance that can serialize and parse it.
+    /// </summary>
+    public interface IFlatBufferSerializable<T> : IFlatBufferSerializable
+        where T : class
+    {
+        /// <summary>
+        /// Gets a <see cref="ISerializer{T}"/> instance that can serialize this object.
+        /// </summary>
+        new ISerializer<T> Serializer { get; }
+    }
+}

--- a/src/FlatSharp.Runtime/ISerializer.cs
+++ b/src/FlatSharp.Runtime/ISerializer.cs
@@ -69,23 +69,9 @@ namespace FlatSharp
     /// <summary>
     /// An object that can read and write <typeparamref name="T"/> from a buffer.
     /// </summary>
-    public interface ISerializer<T> where T : class
+    public interface ISerializer<T> : ISerializer
+        where T : class
     {
-        /// <summary>
-        /// Gets the C# code that FlatSharp generated to produce this serializer.
-        /// </summary>
-        string? CSharp { get; }
-
-        /// <summary>
-        /// Gets the Assembly FlatSharp generated to produce this serializer.
-        /// </summary>
-        Assembly? Assembly { get; }
-
-        /// <summary>
-        /// Gets the raw data of the <see cref="Assembly"/> property. Can be saved to disk and decompiled, referenced, etc.
-        /// </summary>
-        byte[]? AssemblyBytes { get; }
-
         /// <summary>
         /// Writes the given item to the buffer using the given spanwriter.
         /// </summary>
@@ -103,7 +89,7 @@ namespace FlatSharp
         /// <summary>
         /// Parses the given buffer as an instance of <typeparamref name="T"/>.
         /// </summary>
-        T Parse(IInputBuffer buffer);
+        new T Parse(IInputBuffer buffer);
 
         /// <summary>
         /// Returns a new <see cref="ISerializer{T}"/> instance based on the current one with the given settings.


### PR DESCRIPTION
Generated tables contain interfaces that allow access to ```ISerializer<T>```.