### PR TITLE
Simplify unsafe value struct vector access code generation

### DIFF
--- a/src/FlatSharp.Compiler/TypeDefinitions/ValueStructDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/ValueStructDefinition.cs
@@ -170,26 +170,8 @@ namespace FlatSharp.Compiler
                             {
                                 writer.AppendLine($"throw new IndexOutOfRangeException();");
                             }
-
-                            writer.AppendLine($"unsafe");
-                            using (writer.WithBlock())
-                            {
-                                writer.AppendLine($"fixed ({this.Name}* pItem = &item)");
-                                using (writer.WithBlock())
-                                {
-                                    // Get byte* pointer to struct.
-                                    writer.AppendLine($"byte* pByte = (byte*)pItem;");
-
-                                    // Advance to position of the first item in the fector.
-                                    writer.AppendLine($"pByte += {memberModel.Offset};");
-
-                                    // Advance to correct index.
-                                    writer.AppendLine($"pByte += index * sizeof({itemType});");
-
-                                    // return ref.
-                                    writer.AppendLine($"return ref {typeof(Unsafe).GetGlobalCompilableTypeName()}.AsRef<{itemType}>(pByte);");
-                                }
-                            }
+                            
+                            writer.AppendLine($"return ref {typeof(Unsafe).GetGlobalCompilableTypeName()}.Add(ref item.{props[0]}, index);");
                         }
                         else
                         {

--- a/src/Tests/FlatSharpCompilerTests/ValueStructTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/ValueStructTests.cs
@@ -107,15 +107,17 @@ namespace FlatSharpTests.Compiler
 
             string csharp = FlatSharpCompiler.TestHookCreateCSharp(schema, new());
 
+            Assert.Contains("throw new IndexOutOfRangeException()", csharp);
+
             // Syntax for "safe" struct vectors is a giant switch followed by "case {index}: return ref item.__flatsharp__{vecName}_index;
-            // Syntax for unsafe struct vectors is a fixed statement in an unsafe context.
+            // Syntax for unsafe struct vectors is an indexed unsafe field reference access.
 
             // Todo: is there a better way to test this? Attribute? Roslyn? Something else?
             Assert.Contains("case 9: return ref item.__flatsharp_Safe_9", csharp);
             Assert.DoesNotContain("case 9: return ref item.__flatsharp_NotSafe_9", csharp);
 
-            Assert.DoesNotContain("fixed (StructA* pItem = &item)", csharp);
-            Assert.Contains("fixed (StructB* pItem = &item)", csharp);
+            Assert.DoesNotContain("return ref global::System.Runtime.CompilerServices.Unsafe.Add(ref item.__flatsharp_Safe_0, index)", csharp);
+            Assert.Contains("return ref global::System.Runtime.CompilerServices.Unsafe.Add(ref item.__flatsharp_NotSafe_0, index)", csharp);
         }
     }
 }


### PR DESCRIPTION
Since the local fixed variable expires at the moment of scope closure, there's no guarantee that the return value is any safer with it's use.

Simplify this operation to just return the offset reference using a typed `Unsafe.Add` to a reference of the first field.
