### PR TITLE
Experiment: IVector for fs_vector, making use of FlatSharp.Unsafe

### DIFF
--- a/src/FlatSharp.Compiler/TypeDefinitions/PropertyWriter.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/PropertyWriter.cs
@@ -322,6 +322,11 @@ namespace FlatSharp.Compiler
                     string keyType = this.GetIndexedVectorKeyType(context);
                     return $"IIndexedVector<{keyType}, {clrType}>";
 
+                case VectorType.IVector: {
+                    context.NeedsUnsafe = true;
+                    return $"IVector<{clrType}>";
+                }
+
                 case VectorType.None:
                     return clrType;
 

--- a/src/FlatSharp.Compiler/TypeDefinitions/RootNodeDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/RootNodeDefinition.cs
@@ -51,6 +51,10 @@ namespace FlatSharp.Compiler
             writer.AppendLine("using System.Threading.Tasks;");
             writer.AppendLine("using FlatSharp;");
             writer.AppendLine("using FlatSharp.Attributes;");
+            if (context.NeedsUnsafe)
+            {
+                writer.AppendLine("using FlatSharp.Unsafe;");
+            }
 
             // disable obsolete warnings. Flatsharp allows marking default constructors
             // as obsolete and we don't want to raise warnings for our own code.

--- a/src/FlatSharp.Runtime/IVector.cs
+++ b/src/FlatSharp.Runtime/IVector.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2020 James Courtney
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-namespace FlatSharp.Compiler
-{
-    /// <summary>
-    /// Enumerates supported vector types.
-    /// </summary>
-    internal enum VectorType
-    {
-        /// <summary>
-        /// Not a vector.
-        /// </summary>
-        None,
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
-        IList,
-        IReadOnlyList,
-        Array,
-        Memory,
-        ReadOnlyMemory,
-        IIndexedVector,
-        IVector
+namespace FlatSharp
+{
+    [SuppressMessage("ReSharper", "PossibleInterfaceMemberAmbiguity")]
+    public interface IVector<T>
+        : IList<T>, IReadOnlyList<T>
+    {
+        Memory<byte> GetByteMemory();
+
+        Memory<byte> GetByteMemory(int index);
+
+        Memory<byte> GetByteMemory(int index, int length);
+
+        public int Length { get; }
     }
 }

--- a/src/FlatSharp.Unsafe/FlatBufferVector.cs
+++ b/src/FlatSharp.Unsafe/FlatBufferVector.cs
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2020 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace FlatSharp.Unsafe
+{
+
+    using Unsafe = System.Runtime.CompilerServices.Unsafe;
+    public static class FlatBufferVector
+    {
+#if NET5_0_OR_GREATER
+        [return:System.Diagnostics.CodeAnalysis.NotNullIfNotNull("vector")]
+#endif
+        public static IVector<T>? Clone<T>(IVector<T>? vector)
+        {
+            if (vector is null) return null;
+            var range = vector.GetByteMemory();
+            var memory = new Memory<byte>(new byte[range.Length]);
+            range.CopyTo(memory);
+            return new Wrapper<T>(memory);
+        }
+
+        public static IVector<T> Create<T>(Memory<byte> memory)
+        {
+            return new Wrapper<T>(memory);
+        }
+
+        public static IVector<T> Create<T>(byte[] data)
+        {
+            return new Wrapper<T>(new(data));
+        }
+
+        public static IVector<T> Create<T>(T[] items)
+        {
+            return new Wrapper<T>(new ArrayMemoryManager<T>(items).Memory);
+        }
+
+        public static IVector<T> Empty<T>()
+        {
+            return new Wrapper<T>(Memory<byte>.Empty);
+        }
+
+        private class ArrayMemoryManager<T> : MemoryManager<byte>
+        {
+            private readonly Memory<T> memory;
+            private MemoryHandle pin;
+            public ArrayMemoryManager(T[] items)
+            {
+                this.memory = items;
+            }
+            
+            public override Span<byte> GetSpan()
+            {
+                ref var start = ref Unsafe.As<T, byte>(ref this.memory.Span.GetPinnableReference());
+#if NETSTANDARD2_0
+                unsafe
+                {
+                    return new(Unsafe.AsPointer(ref start), Unsafe.SizeOf<T>() * memory.Length);
+                }
+#else
+                return MemoryMarshal.CreateSpan(ref start, Unsafe.SizeOf<T>() * memory.Length);
+#endif
+            }
+
+            public override MemoryHandle Pin(int elementIndex = 0)
+            {
+                return pin = this.memory.Pin();
+            }
+            public override void Unpin()
+            {
+                pin.Dispose();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                pin.Dispose();
+            }
+        }
+
+        private struct Wrapper<T> : IVector<T>
+        {
+            private Memory<byte> memory;
+
+            private static int Size => Unsafe.SizeOf<T>();
+
+            public Wrapper(Memory<byte> memory)
+            {
+                this.memory = memory;
+            }
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private ref T Ref(int offset)
+            {
+                var slice = this.memory.Slice(offset, Size).Span;
+                ref var startOfItem = ref slice.GetPinnableReference();
+                return ref Unsafe.As<byte, T>(ref startOfItem);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Memory<byte> GetByteMemory()
+            {
+                return this.memory;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Memory<byte> GetByteMemory(int index)
+            {
+                var size = Size;
+                return this.memory.Slice(index * size, size);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Memory<byte> GetByteMemory(int index, int length)
+            {
+                var size = Size;
+                return this.memory.Slice(index * size, size * length);
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                for (var offset = 0; offset < this.memory.Length; offset += Size)
+                {
+                    yield return Ref(offset);
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void Add(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public int Count
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get {
+                    return memory.Length / Size;
+                }
+            }
+
+            public int Length
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get {
+                    return Count;
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get {
+                    return true;
+                }
+            }
+
+            public int IndexOf(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Insert(int index, T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
+            public T this[int index]
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get {
+                    return Ref(index);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                set {
+                    Ref(index) = value;
+                }
+            }
+        }
+    }
+}

--- a/src/FlatSharp.Unsafe/FlatSharp.Unsafe.csproj
+++ b/src/FlatSharp.Unsafe/FlatSharp.Unsafe.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FlatSharp.Unsafe</AssemblyName>
     <RootNamespace>FlatSharp.Unsafe</RootNamespace>
@@ -14,11 +14,16 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/FlatSharp/TypeModel/FlatSharpTypeModelProvider.cs
+++ b/src/FlatSharp/TypeModel/FlatSharpTypeModelProvider.cs
@@ -103,6 +103,12 @@ namespace FlatSharp.TypeModel
                     typeModel = new IndexedVectorTypeModel(type, container);
                     return true;
                 }
+
+                if (genericDef == typeof(IVector<>))
+                {
+                    typeModel = new FlatBufferVectorTypeModel(type, container);
+                    return true;
+                }
             }
 
             if (typeof(IFlatBufferUnion).IsAssignableFrom(type))

--- a/src/FlatSharp/TypeModel/Vectors/FlatBufferVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/Vectors/FlatBufferVectorTypeModel.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright 2020 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+namespace FlatSharp.TypeModel
+{
+    using System;
+
+    /// <summary>
+    /// Defines a vector type model for a memory vector of byte.
+    /// </summary>
+    public class FlatBufferVectorTypeModel : BaseVectorTypeModel
+    {
+        internal FlatBufferVectorTypeModel(Type vectorType, TypeModelContainer provider) : base(vectorType, provider)
+        {
+        }
+
+        public override string LengthPropertyName => nameof(Memory<byte>.Length);
+
+        public override Type OnInitialize()
+        {
+            var genericDef = this.ClrType.GetGenericTypeDefinition();
+            if (genericDef != typeof(IVector<>))
+            {
+                throw new InvalidFlatBufferDefinitionException($"IVector vectors must be IVector<> types.");
+            }
+
+            return typeof(byte);
+        }
+
+        protected override string CreateLoop(FlatBufferSerializerOptions options, string vectorVariableName, string numberOfItemsVariableName, string expectedVariableName, string body)
+        {
+            FlatSharpInternal.Assert(false, "Not expecting to do loop get max size for memory vector");
+            throw new Exception();
+        }
+
+        public override CodeGeneratedMethod CreateParseMethodBody(ParserCodeGenContext context)
+        {
+            string method = nameof(InputBufferExtensions.ReadByteMemoryBlock);
+
+            string memoryVectorRead = $"{context.InputBufferVariableName}.{method}({context.OffsetVariableName})";
+
+            string body;
+
+            var resultTypeName = this.ClrType.GetGenericArguments()[0].GetCompilableTypeName();
+            body = WrapFlatSharpUnsafe($"return global::FlatSharp.Unsafe.FlatBufferVector.Create<{resultTypeName}>({memoryVectorRead});");
+
+            return new CodeGeneratedMethod(body);
+        }
+
+        public override CodeGeneratedMethod CreateSerializeMethodBody(SerializationCodeGenContext context)
+        {
+            string body = 
+                $"{context.SpanWriterVariableName}.{nameof(SpanWriterExtensions.WriteReadOnlyByteMemoryBlock)}({context.SpanVariableName}, {context.ValueVariableName}.GetByteMemory(), {context.OffsetVariableName}, {context.SerializationContextVariableName});";
+
+            return new CodeGeneratedMethod(body);
+        }
+
+        public override CodeGeneratedMethod CreateCloneMethodBody(CloneCodeGenContext context)
+        {
+            string body = WrapFlatSharpUnsafe($"return global::FlatSharp.Unsafe.FlatBufferVector.Clone({context.ItemVariableName});");
+            return new CodeGeneratedMethod(body)
+            {
+                IsMethodInline = true,
+            };
+        }
+
+        private string WrapFlatSharpUnsafe(string body)
+        {
+            return "#if FLATSHARP_UNSAFE\n"
+                + $"{body}\n"
+                + "#else\n"
+                + "#warning Must be compiled with FLATSHARP_UNSAFE to use this functionality.\n"
+                + "throw new NotSupportedException(\"Must be compiled with FLATSHARP_UNSAFE to use this functionality.\");\n"
+                + "#endif";
+        }
+    }
+}

--- a/src/FlatSharp/TypeModel/Vectors/ListVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/Vectors/ListVectorTypeModel.cs
@@ -39,7 +39,7 @@ namespace FlatSharp.TypeModel
 
             FlatSharpInternal.Assert(
                 genericDef == typeof(IList<>) || genericDef == typeof(IReadOnlyList<>),
-                "Cannot build a vector from type: { this.ClrType}. Only List, ReadOnlyList, Memory, ReadOnlyMemory, and Arrays are supported.");
+                $"Cannot build a vector from type: {this.ClrType}. Only IVector, IList, IReadOnlyList, Memory, ReadOnlyMemory, and Arrays are supported.");
 
             this.isReadOnly = genericDef == typeof(IReadOnlyList<>);
             return this.ClrType.GetGenericArguments()[0];

--- a/src/Tests/FlatSharpCompilerTests/CopyConstructorTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/CopyConstructorTests.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using FlatSharp.Unsafe;
+
 namespace FlatSharpTests.Compiler
 {
     using System;
@@ -53,15 +55,18 @@ table OuterTable ({MetadataKeys.SerializerKind}: ""Greedy"") {{
   IntVector_List:[int] ({MetadataKeys.VectorKind}:""IList"", id: 9);
   IntVector_RoList:[int] ({MetadataKeys.VectorKind}:""IReadOnlyList"", id: 10);
   IntVector_Array:[int] ({MetadataKeys.VectorKind}:""Array"", id: 11);
+  IntVector_Vector:[int] ({MetadataKeys.VectorKind}:""IVector"", id: 12);
   
-  TableVector_List:[InnerTable] ({MetadataKeys.VectorKind}:""IList"", id: 12);
-  TableVector_RoList:[InnerTable] ({MetadataKeys.VectorKind}:""IReadOnlyList"", id: 13);
-  TableVector_Indexed:[InnerTable] ({MetadataKeys.VectorKind}:""IIndexedVector"", id: 14);
-  TableVector_Array:[InnerTable] ({MetadataKeys.VectorKindLegacy}:""Array"", id: 15);
+  TableVector_List:[InnerTable] ({MetadataKeys.VectorKind}:""IList"", id: 13);
+  TableVector_RoList:[InnerTable] ({MetadataKeys.VectorKind}:""IReadOnlyList"", id: 14);
+  TableVector_Indexed:[InnerTable] ({MetadataKeys.VectorKind}:""IIndexedVector"", id: 15);
+  TableVector_Array:[InnerTable] ({MetadataKeys.VectorKindLegacy}:""Array"", id: 16);
+  TableVector_Vector:[InnerTable] ({MetadataKeys.VectorKind}:""IVector"", id: 17);
 
-  ByteVector:[ubyte] ({MetadataKeys.VectorKind}:""Memory"", id: 16);
-  ByteVector_RO:[ubyte] ({MetadataKeys.VectorKind}:""ReadOnlyMemory"", id: 17);
-  Union:Union (id: 18);
+  ByteVector:[ubyte] ({MetadataKeys.VectorKind}:""Memory"", id: 18);
+  ByteVector_RO:[ubyte] ({MetadataKeys.VectorKind}:""ReadOnlyMemory"", id: 19);
+  ByteVector_Vector:[ubyte] ({MetadataKeys.VectorKind}:""IVector"", id: 20);
+  Union:Union (id: 21);
 }}
 
 struct OuterStruct {{
@@ -97,11 +102,13 @@ table InnerTable {{
                 IntVector_Array = new[] { 7, 8, 9, },
                 IntVector_List = new[] { 10, 11, 12, }.ToList(),
                 IntVector_RoList = new[] { 13, 14, 15 }.ToList(),
+                IntVector_Vector = FlatBufferVector.Create( new[] { 13, 14, 15 }),
 
                 TableVector_Array = CreateInner("Rocket", "Molly", "Clementine"),
                 TableVector_Indexed = new IndexedVector<string, InnerTable>(CreateInner("Pudge", "Sunshine", "Gypsy"), false),
                 TableVector_List = CreateInner("Finnegan", "Daisy"),
                 TableVector_RoList = CreateInner("Gordita", "Lunchbox"),
+                TableVector_Vector = FlatBufferVector.Create( CreateInner("Gordita", "Lunchbox")),
 
                 Union = new FlatBufferUnion<OuterTable, InnerTable, OuterStruct, InnerStruct>(new OuterStruct())
             };
@@ -316,24 +323,33 @@ table InnerTable {{
             public int[]? IntVector_Array { get; set; }
 
             [FlatBufferItem(12)]
-            public IList<InnerTable>? TableVector_List { get; set; }
+            public IVector<int>? IntVector_Vector { get; set; }
 
             [FlatBufferItem(13)]
-            public IReadOnlyList<InnerTable>? TableVector_RoList { get; set; }
+            public IList<InnerTable>? TableVector_List { get; set; }
 
             [FlatBufferItem(14)]
-            public IIndexedVector<string, InnerTable>? TableVector_Indexed { get; set; }
+            public IReadOnlyList<InnerTable>? TableVector_RoList { get; set; }
 
             [FlatBufferItem(15)]
-            public InnerTable[]? TableVector_Array { get; set; }
+            public IIndexedVector<string, InnerTable>? TableVector_Indexed { get; set; }
 
             [FlatBufferItem(16)]
-            public Memory<byte>? ByteVector { get; set; }
+            public InnerTable[]? TableVector_Array { get; set; }
 
             [FlatBufferItem(17)]
-            public ReadOnlyMemory<byte>? ByteVector_RO { get; set; }
+            public IVector<InnerTable>? TableVector_Vector { get; set; }
 
             [FlatBufferItem(18)]
+            public Memory<byte>? ByteVector { get; set; }
+
+            [FlatBufferItem(19)]
+            public ReadOnlyMemory<byte>? ByteVector_RO { get; set; }
+
+            [FlatBufferItem(20)]
+            public IVector<byte>? ByteVector_Vector { get; set; }
+
+            [FlatBufferItem(21)]
             public FlatBufferUnion<OuterTable, InnerTable, OuterStruct, InnerStruct>? Union { get; set; }
         }
 

--- a/src/Tests/FlatSharpCompilerTests/VectorOfUnionTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/VectorOfUnionTests.cs
@@ -34,7 +34,7 @@ namespace FlatSharpTests.Compiler
         [Fact]
         public void VectorOfUnion_CompilerTests()
         {
-            foreach (var vectorKind in new[] { "IList", "IReadOnlyList", "Array" })
+            foreach (var vectorKind in new[] { "IList", "IReadOnlyList", "Array", "IVector" })
             {
                 foreach (FlatBufferDeserializationOption option in Enum.GetValues(typeof(FlatBufferDeserializationOption)))
                 {

--- a/src/Tests/FlatSharpTests/ClassLib/TypeModelTests.cs
+++ b/src/Tests/FlatSharpTests/ClassLib/TypeModelTests.cs
@@ -729,6 +729,13 @@ namespace FlatSharpTests
             var model = RuntimeTypeModel.CreateFrom(typeof(Memory<byte>?));
             Assert.IsType<NullableTypeModel>(model);
         }
+        
+        [Fact]
+        public void TypeModel_Vector_IVectorOfByte()
+        {
+            var model = this.VectorTest(typeof(IVector<>), typeof(byte));
+            Assert.IsType<FlatBufferVectorTypeModel>(model);
+        }
 
         [Fact]
         public void TypeModel_Vector_NullableReadOnlyMemoryOfByte()


### PR DESCRIPTION
This is just an experiment, it's probably not a good idea.

Implement IVector<T>, a Memory<byte> and IList<T> work-alike.

Extend FlatBufferVector to implement IVector.

Add unsafe creation of FlatBufferVector to FlatSharp.Unsafe.

Has post-generation compile time warnings when FlatSharp.Unsafe is required.

Probably has all sorts of problems.

Gives direct access to backing memory for struct vectors, as has been already done elsewhere.

