### PR TITLE
Offset Model (8-bit, 16-bit, 64-bit offset sizes, file identifier sizes)

### DIFF
--- a/src/FlatSharp.Compiler/CompilerOptions.cs
+++ b/src/FlatSharp.Compiler/CompilerOptions.cs
@@ -28,5 +28,14 @@ namespace FlatSharp.Compiler
 
         [Option("nullable-warnings", Default = false)]
         public bool? NullableWarnings { get; set; }
+
+        [Option('s', "offset-size")]
+        public int? OffsetSize { get; set; }
+
+        [Option( "file-identifier-size")]
+        public int? FileIdentifierSize { get; set; }
+        
+        [Option("strict-file-identifier-size")]
+        public bool? StrictFileIdentifierSize { get; set; }
     }
 }

--- a/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
+++ b/src/FlatSharp.Compiler/FlatSharp.Compiler.targets
@@ -33,7 +33,7 @@
 
     <Message Text="$(TargetFramework) $(TargetFrameworkIdentifier): $(CompilerInvocation) --nullable-annotations $(FlatSharpNullable) --input &quot;%(FlatSharpSchema.fullpath)&quot; --output $(IntermediateOutputPath)" Importance="high" />
     <Exec 
-        Command="$(CompilerInvocation) --nullable-warnings $(FlatSharpNullable) --input &quot;%(FlatSharpSchema.fullpath)&quot; --output $(IntermediateOutputPath) "
+        Command="$(CompilerInvocation) $(FlatSharpCompilerOptions) --nullable-warnings $(FlatSharpNullable) --input &quot;%(FlatSharpSchema.fullpath)&quot; --output $(IntermediateOutputPath) "
         CustomErrorRegularExpression=".*" 
         Condition=" '%(FlatSharpSchema.fullpath)' != '' " />
     

--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -371,15 +371,32 @@ namespace FlatSharp.Compiler
 
                     writer = new CodeWriter();
 
+                    TypeModelContainer container;
+                    
+                    if (localOptions.OffsetSize == null
+                        && localOptions.FileIdentifierSize == null
+                        && localOptions.StrictFileIdentifierSize == null)
+                    {
+                        container = TypeModelContainer.CreateDefault();
+                    }
+                    else
+                    {
+                        container = TypeModelContainer.CreateDefault(new(
+                            localOptions.OffsetSize,
+                            localOptions.FileIdentifierSize,
+                            localOptions.StrictFileIdentifierSize
+                        ));
+                    }
+
                     rootNode.WriteCode(
                         writer,
                         new CompileContext
                         {
                             CompilePass = step,
                             Options = localOptions,
-                            RootFile = rootNode.DeclaringFile,
+                            RootFile = rootNode.DeclaringFile ?? string.Empty,
                             PreviousAssembly = assembly,
-                            TypeModelContainer = TypeModelContainer.CreateDefault(),
+                            TypeModelContainer = container,
                         });
 
                     ErrorContext.Current.ThrowIfHasErrors();

--- a/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
+++ b/src/FlatSharp.Compiler/TypeDefinitions/TableOrStructDefinition.cs
@@ -50,7 +50,7 @@ namespace FlatSharp.Compiler
 
         public DefaultConstructorKind? DefaultConstructorKind { get; set; }
 
-        public string? FileIdentifier { get; set; }
+        public string? FileIdentifier;
 
         public FlatBufferDeserializationOption? RequestedSerializer { get; set; }
 
@@ -158,6 +158,7 @@ namespace FlatSharp.Compiler
 
             if (this.IsTable && !string.IsNullOrEmpty(this.FileIdentifier))
             {
+                context.TypeModelContainer.OffsetModel.ValidateFileIdentifier(ref this.FileIdentifier);
                 attributeParts.Add($"{nameof(FlatBufferTableAttribute.FileIdentifier)} = \"{this.FileIdentifier}\"");
             }
 

--- a/src/FlatSharp.Runtime/Attributes/FlatBufferTableAttribute.cs
+++ b/src/FlatSharp.Runtime/Attributes/FlatBufferTableAttribute.cs
@@ -27,6 +27,6 @@ namespace FlatSharp.Attributes
         /// <summary>
         /// Specifies the file identifier for serialized tables. Must be precisely 4 ASCII characters.
         /// </summary>
-        public string? FileIdentifier { get; set; }
+        public string? FileIdentifier;
     }
 }

--- a/src/FlatSharp/FlatBufferSerializer.cs
+++ b/src/FlatSharp/FlatBufferSerializer.cs
@@ -48,7 +48,7 @@ namespace FlatSharp
         /// Creates a new FlatBufferSerializer using the given options.
         /// </summary>
         public FlatBufferSerializer(FlatBufferSerializerOptions options) 
-            : this(options, TypeModelContainer.CreateDefault())
+            : this(options, TypeModelContainer.CreateDefault(new(options.OffsetSize, options.FileIdentifierSize, options.StrictFileIdentifierSize)))
         {
         }
 

--- a/src/FlatSharp/FlatBufferSerializerOptions.cs
+++ b/src/FlatSharp/FlatBufferSerializerOptions.cs
@@ -118,5 +118,20 @@ namespace FlatSharp
         /// Indicates if "protected internal" modifiers should be converted to protected.
         /// </summary>
         internal bool ConvertProtectedInternalToProtected { get; set; } = true;
+
+        /// <summary>
+        /// Specify the offset size
+        /// </summary>
+        public int? OffsetSize { get; set; } = null;
+
+        /// <summary>
+        /// Specify the size of the file identifier.
+        /// </summary>
+        public int? FileIdentifierSize { get; set; } = null;
+        
+        /// <summary>
+        /// Specify if the size of the file identifier is strict.
+        /// </summary>
+        public bool? StrictFileIdentifierSize { get; set; } = null;
     }
 }

--- a/src/FlatSharp/FlatSharp.csproj
+++ b/src/FlatSharp/FlatSharp.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="3.8.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.Net.Compilers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime</IncludeAssets>
     </PackageReference>

--- a/src/FlatSharp/OffsetModel.cs
+++ b/src/FlatSharp/OffsetModel.cs
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace FlatSharp.TypeModel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
+
+    /// <summary>
+    /// Common or shared type model properties.
+    /// </summary>
+    public class OffsetModel
+    {
+        public static readonly OffsetModel Default = new(4);
+
+        public int OffsetSize;
+        public int FileIdentifierSize;
+        public bool StrictFileIdentifierSize;
+
+        public OffsetModel(int offsetSize, int fileIdentifierSize, bool strictFileIdentifierSize)
+        {
+            OffsetSize = offsetSize;
+            FileIdentifierSize = fileIdentifierSize;
+            StrictFileIdentifierSize = strictFileIdentifierSize;
+        }
+
+        public OffsetModel(int offsetSize, int fileIdentifierSize) : this(offsetSize, fileIdentifierSize, fileIdentifierSize == 4)
+        {
+        }
+
+        public OffsetModel(int offsetSize) : this(offsetSize, offsetSize, offsetSize == 4)
+        {
+        }
+
+        public OffsetModel(int? offsetSize, int? fileIdentifierSize, bool? strictFileIdentifierSize)
+        {
+            OffsetSize = offsetSize ?? 4;
+            FileIdentifierSize = fileIdentifierSize ?? OffsetSize;
+            StrictFileIdentifierSize = strictFileIdentifierSize ?? FileIdentifierSize == 4;
+        }
+        
+        public void ValidateFileIdentifier(ref string? fileIdentifier)
+        {
+            if (string.IsNullOrEmpty(fileIdentifier)) return;
+
+            if (fileIdentifier.Length != FileIdentifierSize)
+            {
+                if (StrictFileIdentifierSize)
+                {
+                    throw new InvalidFlatBufferDefinitionException(
+                        $"File identifier '{fileIdentifier}' is invalid. FileIdentifiers must be exactly {FileIdentifierSize} ASCII characters.");
+                }
+                    
+                fileIdentifier = fileIdentifier.Length > FileIdentifierSize
+                    ? fileIdentifier.Substring(0, FileIdentifierSize)
+                    : fileIdentifier.PadRight(FileIdentifierSize, '\0');
+            }
+
+            foreach (var c in fileIdentifier)
+            {
+                if (c < 128) continue;
+
+                throw new InvalidFlatBufferDefinitionException($"File identifier '{fileIdentifier}' contains non-ASCII characters. Character '{c}' is invalid.");
+            }
+        }
+    }
+}

--- a/src/FlatSharp/TypeModel/EnumTypeModel.cs
+++ b/src/FlatSharp/TypeModel/EnumTypeModel.cs
@@ -30,7 +30,7 @@
     {
         private ITypeModel underlyingTypeModel;
 
-        internal EnumTypeModel(Type type, TypeModelContainer typeModelContainer) : base(type, typeModelContainer)
+        internal EnumTypeModel(Type type, TypeModelContainer typeModelContainer) : base(type, typeModelContainer, typeModelContainer.OffsetModel)
         {
             this.underlyingTypeModel = null!;
         }

--- a/src/FlatSharp/TypeModel/ITypeModel.cs
+++ b/src/FlatSharp/TypeModel/ITypeModel.cs
@@ -27,6 +27,8 @@ namespace FlatSharp.TypeModel
     /// </summary>
     public interface ITypeModel
     {
+        OffsetModel OffsetModel { get; }
+        
         /// <summary>
         /// Gets the schema element type that this type model represents. Note that this is not a 1:1 relationship with the type of class. There can
         /// be multiple implementations of ITypeModel that satisfy a particular schema type.

--- a/src/FlatSharp/TypeModel/ItemMemberModel.cs
+++ b/src/FlatSharp/TypeModel/ItemMemberModel.cs
@@ -43,6 +43,7 @@ namespace FlatSharp.TypeModel
             var setMethod = propertyInfo.SetMethod;
 
             this.ItemTypeModel = propertyModel;
+            this.OffsetModel = propertyModel.OffsetModel;
             this.PropertyInfo = propertyInfo;
             this.Index = attribute.Index;
             this.CustomAccessor = propertyInfo.GetFlatBufferMetadataOrNull(FlatBufferMetadataKind.Accessor);
@@ -102,6 +103,8 @@ namespace FlatSharp.TypeModel
                 }
             }
         }
+        
+        public OffsetModel OffsetModel { get; }
 
         private static bool CanBeOverridden(MethodInfo method)
         {

--- a/src/FlatSharp/TypeModel/NullableTypeModel.cs
+++ b/src/FlatSharp/TypeModel/NullableTypeModel.cs
@@ -29,7 +29,7 @@ namespace FlatSharp.TypeModel
         private Type underlyingType;
         private ITypeModel underlyingTypeModel;
 
-        internal NullableTypeModel(TypeModelContainer container, Type type) : base(type, container)
+        internal NullableTypeModel(TypeModelContainer container, Type type) : base(type, container, container.OffsetModel)
         {
             this.underlyingType = null!;
             this.underlyingTypeModel = null!;

--- a/src/FlatSharp/TypeModel/RuntimeTypeModel.cs
+++ b/src/FlatSharp/TypeModel/RuntimeTypeModel.cs
@@ -31,11 +31,17 @@ namespace FlatSharp.TypeModel
     {
         protected readonly TypeModelContainer typeModelContainer;
 
-        internal RuntimeTypeModel(Type clrType, TypeModelContainer typeModelContainer)
+        internal RuntimeTypeModel(Type clrType, TypeModelContainer typeModelContainer, OffsetModel offsetModel)
         {
             this.ClrType = clrType;
             this.typeModelContainer = typeModelContainer;
+            OffsetModel = offsetModel;
         }
+
+        /// <summary>
+        /// The offset model for serialization.
+        /// </summary>
+        public OffsetModel OffsetModel { get; }
 
         /// <summary>
         /// Initializes this runtime type model instance.
@@ -122,7 +128,15 @@ namespace FlatSharp.TypeModel
         /// </summary>
         internal static ITypeModel CreateFrom(Type type)
         {
-            return TypeModelContainer.CreateDefault().CreateTypeModel(type);
+            return CreateFrom(TypeModelContainer.CreateDefault(), type);
+        }
+        
+        /// <summary>
+        /// Gets or creates a runtime type model from the given type. This is only used in test cases any more.
+        /// </summary>
+        internal static ITypeModel CreateFrom(TypeModelContainer container, Type type)
+        {
+            return container.CreateTypeModel(type);
         }
 
         public abstract CodeGeneratedMethod CreateSerializeMethodBody(SerializationCodeGenContext context);

--- a/src/FlatSharp/TypeModel/ScalarTypeModel.cs
+++ b/src/FlatSharp/TypeModel/ScalarTypeModel.cs
@@ -31,7 +31,7 @@
         internal ScalarTypeModel(
             TypeModelContainer container,
             Type type,
-            int size) : base(type, container)
+            int size) : base(type, container, container.OffsetModel)
         {
             this.size = size;
         }

--- a/src/FlatSharp/TypeModel/SharedStringTypeModel.cs
+++ b/src/FlatSharp/TypeModel/SharedStringTypeModel.cs
@@ -25,7 +25,7 @@ namespace FlatSharp.TypeModel
     /// </summary>
     public class SharedStringTypeModel : RuntimeTypeModel, ITypeModel
     {
-        internal SharedStringTypeModel(TypeModelContainer container) : base(typeof(SharedString), container)
+        internal SharedStringTypeModel(TypeModelContainer container) : base(typeof(SharedString), container, container.OffsetModel)
         {
         }
 

--- a/src/FlatSharp/TypeModel/StringTypeModel.cs
+++ b/src/FlatSharp/TypeModel/StringTypeModel.cs
@@ -25,8 +25,7 @@ namespace FlatSharp.TypeModel
     /// </summary>
     public class StringTypeModel : RuntimeTypeModel
     {
-        internal StringTypeModel(TypeModelContainer container) : base(typeof(string), container)
-        {
+        internal StringTypeModel(TypeModelContainer container) : base(typeof(string), container, container.OffsetModel)     {
         }
 
         /// <summary>

--- a/src/FlatSharp/TypeModel/StructTypeModel.cs
+++ b/src/FlatSharp/TypeModel/StructTypeModel.cs
@@ -37,7 +37,7 @@ namespace FlatSharp.TypeModel
         private MethodInfo? onDeserializeMethod;
         private FlatBufferStructAttribute attribute = null!;
 
-        internal StructTypeModel(Type clrType, TypeModelContainer container) : base(clrType, container)
+        internal StructTypeModel(Type clrType, TypeModelContainer container) : base(clrType, container, container.OffsetModel)
         {
         }
 

--- a/src/FlatSharp/TypeModel/TableMemberModel.cs
+++ b/src/FlatSharp/TypeModel/TableMemberModel.cs
@@ -118,7 +118,7 @@
                     {this.GetNotPresentStatement()}
                 }}
 
-                ushort relativeOffset = buffer.ReadUShort({vtableLocationVariableName} + {4 + (2 * this.Index)});
+                ushort relativeOffset = buffer.ReadUShort({vtableLocationVariableName} + {OffsetModel.OffsetSize + (2 * this.Index)});
                 if (relativeOffset == 0)
                 {{
                     {this.GetNotPresentStatement()}
@@ -140,7 +140,7 @@
                 int idx = this.Index + i;
 
                 relativeOffsets.Add($@"
-                ushort relativeOffset{i} = buffer.ReadUShort({vtableLocationVariableName} + {4 + (2 * idx)});
+                ushort relativeOffset{i} = buffer.ReadUShort({vtableLocationVariableName} + {OffsetModel.OffsetSize + (2 * idx)});
                 if (relativeOffset{i} == 0)
                 {{
                     {this.GetNotPresentStatement()}

--- a/src/FlatSharp/TypeModel/TypeFacadeTypeModelProvider.cs
+++ b/src/FlatSharp/TypeModel/TypeFacadeTypeModelProvider.cs
@@ -32,9 +32,9 @@ namespace FlatSharp.TypeModel
         private readonly ITypeModel model;
 
         public TypeFacadeTypeModelProvider(
-            ITypeModel underlyingModel)
+            ITypeModel underlyingModel, OffsetModel offsetModel)
         {
-            this.model = new TypeFacadeTypeModel(underlyingModel);
+            this.model = new TypeFacadeTypeModel(underlyingModel, offsetModel);
         }
 
         public bool TryCreateTypeModel(TypeModelContainer container, Type type, [NotNullWhen(true)] out ITypeModel? typeModel)
@@ -60,12 +60,16 @@ namespace FlatSharp.TypeModel
             private readonly ITypeModel underlyingModel;
 
             public TypeFacadeTypeModel(
-                ITypeModel underlyingModel)
+                ITypeModel underlyingModel,
+                OffsetModel offsetModel)
             {
                 this.underlyingModel = underlyingModel;
+                this.OffsetModel = offsetModel;
             }
 
             public FlatBufferSchemaType SchemaType => this.underlyingModel.SchemaType;
+            
+            public  OffsetModel OffsetModel { get; }
 
             public Type ClrType => typeof(TType);
 

--- a/src/FlatSharp/TypeModel/UnionTypeModel.cs
+++ b/src/FlatSharp/TypeModel/UnionTypeModel.cs
@@ -29,7 +29,7 @@ namespace FlatSharp.TypeModel
     {
         private ITypeModel[] memberTypeModels;
 
-        internal UnionTypeModel(Type unionType, TypeModelContainer provider) : base(unionType, provider)
+        internal UnionTypeModel(Type unionType, TypeModelContainer provider) : base(unionType, provider, provider.OffsetModel)
         {
             this.memberTypeModels = null!;
         }

--- a/src/FlatSharp/TypeModel/ValueStructTypeModel.cs
+++ b/src/FlatSharp/TypeModel/ValueStructTypeModel.cs
@@ -36,7 +36,7 @@
         private int inlineSize;
         private int maxAlignment = 1;
 
-        internal ValueStructTypeModel(Type clrType, TypeModelContainer container) : base(clrType, container)
+        internal ValueStructTypeModel(Type clrType, TypeModelContainer container) : base(clrType, container, container.OffsetModel)
         {
         }
 

--- a/src/FlatSharp/TypeModel/Vectors/BaseVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/Vectors/BaseVectorTypeModel.cs
@@ -29,7 +29,7 @@ namespace FlatSharp.TypeModel
         // count of items + padding(uoffset_t);
         protected static readonly int VectorMinSize = sizeof(uint) + SerializationHelpers.GetMaxPadding(sizeof(uint));
 
-        internal BaseVectorTypeModel(Type vectorType, TypeModelContainer provider) : base(vectorType, provider)
+        internal BaseVectorTypeModel(Type vectorType, TypeModelContainer provider) : base(vectorType, provider, provider.OffsetModel)
         {
             this.ItemTypeModel = null!;
         }
@@ -160,7 +160,7 @@ namespace FlatSharp.TypeModel
                 int vectorOffset = {context.SerializationContextVariableName}.{nameof(SerializationContext.AllocateVector)}({itemTypeModel.PhysicalLayout[0].Alignment}, count, {this.PaddedMemberInlineSize});
                 {context.SpanWriterVariableName}.{nameof(SpanWriterExtensions.WriteUOffset)}({context.SpanVariableName}, {context.OffsetVariableName}, vectorOffset);
                 {context.SpanWriterVariableName}.{nameof(SpanWriter.WriteInt)}({context.SpanVariableName}, count, vectorOffset);
-                vectorOffset += sizeof(int);
+                vectorOffset += {OffsetModel.OffsetSize};
 
                 {this.CreateLoop(context.Options, context.ValueVariableName, "count", "current", loopBody)}";
 

--- a/src/Tests/FlatSharpCompilerTests/FileIdentifierTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/FileIdentifierTests.cs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+using FlatSharp.TypeModel;
+
 namespace FlatSharpTests.Compiler
 {
     using System;
@@ -27,8 +30,17 @@ namespace FlatSharpTests.Compiler
     
     public class FileIdentifierTests
     {
-        [Fact]
-        public void Multiple_Root_Types_Different_Namespaces()
+        public static readonly IEnumerable<object[]> OffsetSizes = new[]
+        {
+            new object[] { 1 },
+            new object[] { 2 },
+            new object[] { 4 },
+            new object[] { 8 }
+        };
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Multiple_Root_Types_Different_Namespaces(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -41,12 +53,13 @@ namespace FlatSharpTests.Compiler
             file_identifier ""food"";
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='Duplicate root types: 'Table' and 'TableB'.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Multiple_Root_Types_Same_Namespace()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Multiple_Root_Types_Same_Namespace(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -56,12 +69,13 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='Duplicate root types: 'Table' and 'Table'.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Multiple_File_Identifiers_Different_Namespaces()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Multiple_File_Identifiers_Different_Namespaces(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -74,12 +88,13 @@ namespace FlatSharpTests.Compiler
             file_identifier ""food"";
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize}));
             Assert.StartsWith("Message='Duplicate file identifiers: 'doof' and 'food'.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Multiple_File_Identifiers_Same_Namespace()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Multiple_File_Identifiers_Same_Namespace(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -89,12 +104,13 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='Duplicate file identifiers: 'food' and 'doof'.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Unknown_Root_Type_No_File_Identifier()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Unknown_Root_Type_No_File_Identifier(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -102,12 +118,13 @@ namespace FlatSharpTests.Compiler
             root_type Something;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='Unable to resolve root_type 'Something'.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Struct_Root_Type()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Struct_Root_Type(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -116,12 +133,13 @@ namespace FlatSharpTests.Compiler
             root_type Struct;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='root_type 'Struct' does not reference a table.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Enum_Root_Type()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Enum_Root_Type(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -130,12 +148,13 @@ namespace FlatSharpTests.Compiler
             root_type Enum;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='root_type 'Enum' does not reference a table.', Scope=$", ex.Errors[0]);
         }
 
-        [Fact]
-        public void Unknown_Root_Type_With_File_Identifier()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Unknown_Root_Type_With_File_Identifier(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -144,12 +163,13 @@ namespace FlatSharpTests.Compiler
             file_identifier ""abcd"";
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='Unable to resolve root_type 'Something'.', Scope=$", ex.Errors[0]);
         }
-
-        [Fact]
-        public void File_Identifier_With_No_Root_Type()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void File_Identifier_With_No_Root_Type(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -157,13 +177,14 @@ namespace FlatSharpTests.Compiler
             file_identifier ""abcd"";
             ";
 
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
             Assert.Null(
                 asm.GetType("FileIdTests.A.Table").GetCustomAttribute<FlatBufferTableAttribute>().FileIdentifier);
         }
-
-        [Fact]
-        public void Root_Type_With_No_File_Identifier()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Root_Type_With_No_File_Identifier(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -171,13 +192,14 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
             Assert.Null(
                 asm.GetType("FileIdTests.A.Table").GetCustomAttribute<FlatBufferTableAttribute>().FileIdentifier);
         }
-
-        [Fact]
-        public void File_Identifier_With_Manually_Specified_Id()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void File_Identifier_With_Manually_Specified_Id(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -186,14 +208,18 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
+            
+            string fileIdentifier = "AbCd";
+            if (offsetSize != 4) new OffsetModel(offsetSize).ValidateFileIdentifier(ref fileIdentifier);
             Assert.Equal(
-                "AbCd",
+                fileIdentifier,
                 asm.GetType("FileIdTests.A.Table").GetCustomAttribute<FlatBufferTableAttribute>().FileIdentifier);
         }
-
-        [Fact]
-        public void File_Identifier_With_Manually_Specified_Id_Conflict()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void File_Identifier_With_Manually_Specified_Id_Conflict(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -202,12 +228,13 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
+            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
             Assert.StartsWith("Message='root_type 'Table' has conflicting file identifiers: 'AbCd' and 'abcd'.', Scope=$", ex.Errors[0]);
         }
-
-        [Fact]
-        public void Manually_Specified_Id_With_No_File_Id()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Manually_Specified_Id_With_No_File_Id(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -215,14 +242,17 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
+            string fileIdentifier = "AbCd";
+            if (offsetSize != 4) new OffsetModel(offsetSize).ValidateFileIdentifier(ref fileIdentifier);
             Assert.Equal(
-                "AbCd",
+                fileIdentifier,
                 asm.GetType("FileIdTests.A.Table").GetCustomAttribute<FlatBufferTableAttribute>().FileIdentifier);
         }
-
-        [Fact]
-        public void Manually_Specified_Id_With_No_File_Id_Unquoted()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Manually_Specified_Id_With_No_File_Id_Unquoted(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -230,14 +260,17 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
+            string fileIdentifier = "AbCd";
+            if (offsetSize != 4) new OffsetModel(offsetSize).ValidateFileIdentifier(ref fileIdentifier);
             Assert.Equal(
-                "AbCd",
+                fileIdentifier,
                 asm.GetType("FileIdTests.A.Table").GetCustomAttribute<FlatBufferTableAttribute>().FileIdentifier);
         }
-
-        [Fact]
-        public void Manually_Specified_Id_TooLong()
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void Manually_Specified_Id_TooLong(int offsetSize)
         {
             string schema = $@"
             namespace FileIdTests.A;
@@ -245,8 +278,21 @@ namespace FlatSharpTests.Compiler
             root_type Table;
             ";
 
-            var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
-            Assert.Equal("Message='File identifier 'AbCdefg' is invalid. FileIdentifiers must be exactly 4 ASCII characters.', Scope=$.", ex.Errors[0]);
+            if (offsetSize == 4)
+            {
+                var ex = Assert.Throws<InvalidFbsFileException>(()
+                    => FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize }));
+                Assert.Equal("Message='File identifier 'AbCdefg' is invalid. FileIdentifiers must be exactly 4 ASCII characters.', Scope=$..FileIdTests.A.Table",
+                    ex.Errors[0]);
+            }
+            else
+            {
+                Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { OffsetSize = offsetSize });
+                string fileIdentifier = "AbCdefg";
+                new OffsetModel(offsetSize).ValidateFileIdentifier(ref fileIdentifier);
+                Assert.Equal(fileIdentifier,
+                    asm.GetType("FileIdTests.A.Table")!.GetCustomAttribute<FlatBufferTableAttribute>()!.FileIdentifier);
+            }
         }
     }
 }

--- a/src/Tests/FlatSharpCompilerTests/StructVectorTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/StructVectorTests.cs
@@ -31,49 +31,71 @@ namespace FlatSharpTests.Compiler
     
     public class StructVectorTests
     {
-        [Fact]
-        public void StructVector_Byte_NegativeLength() 
-            => Assert.Throws<InvalidFbsFileException>(() => this.RunTest<byte>("ubyte", -3, FlatBufferDeserializationOption.Greedy));
+        public static readonly IEnumerable<object[]> OffsetSizes = new[]
+        {
+            new object[] { 1 },
+            new object[] { 2 },
+            new object[] { 4 },
+            new object[] { 8 }
+        };
+        
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Byte_NegativeLength(int offsetSize)
+            => Assert.Throws<InvalidFbsFileException>(() => this.RunTest<byte>("ubyte", -3, FlatBufferDeserializationOption.Greedy, offsetSize));
 
-        [Fact]
-        public void StructVector_Byte_ZeroLength()
-            => Assert.Throws<InvalidFbsFileException>(() => this.RunTest<byte>("ubyte", 0, FlatBufferDeserializationOption.Greedy));
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Byte_ZeroLength(int offsetSize)
+            => Assert.Throws<InvalidFbsFileException>(() => this.RunTest<byte>("ubyte", 0, FlatBufferDeserializationOption.Greedy, offsetSize));
 
-        [Fact]
-        public void StructVector_Byte() => this.RunTest<byte>("ubyte", 1, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Byte(int offsetSize) => this.RunTest<byte>("ubyte", 1, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_SByte() => this.RunTest<sbyte>("byte", 2, FlatBufferDeserializationOption.GreedyMutable);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_SByte(int offsetSize) => this.RunTest<sbyte>("byte", 2, FlatBufferDeserializationOption.GreedyMutable, offsetSize);
 
-        [Fact]
-        public void StructVector_Bool() => this.RunTest<bool>("bool", 3, FlatBufferDeserializationOption.VectorCache);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Bool(int offsetSize) => this.RunTest<bool>("bool", 3, FlatBufferDeserializationOption.VectorCache, offsetSize);
 
-        [Fact]
-        public void StructVector_UShort() => this.RunTest<ushort>("ushort", 4, FlatBufferDeserializationOption.VectorCacheMutable);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_UShort(int offsetSize) => this.RunTest<ushort>("ushort", 4, FlatBufferDeserializationOption.VectorCacheMutable, offsetSize);
 
-        [Fact]
-        public void StructVector_Short() => this.RunTest<short>("short", 5, FlatBufferDeserializationOption.PropertyCache);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Short(int offsetSize) => this.RunTest<short>("short", 5, FlatBufferDeserializationOption.PropertyCache, offsetSize);
 
-        [Fact]
-        public void StructVector_UInt() => this.RunTest<uint>("uint", 6, FlatBufferDeserializationOption.Lazy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_UInt(int offsetSize) => this.RunTest<uint>("uint", 6, FlatBufferDeserializationOption.Lazy, offsetSize);
 
-        [Fact]
-        public void StructVector_Int() => this.RunTest<int>("int", 7, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Int(int offsetSize) => this.RunTest<int>("int", 7, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_ULong() => this.RunTest<ulong>("ulong", 8, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_ULong(int offsetSize) => this.RunTest<ulong>("ulong", 8, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_Long() => this.RunTest<long>("long", 9, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Long(int offsetSize) => this.RunTest<long>("long", 9, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_Float() => this.RunTest<float>("float", 10, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Float(int offsetSize) => this.RunTest<float>("float", 10, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_Double() => this.RunTest<double>("double", 11, FlatBufferDeserializationOption.Greedy);
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_Double(int offsetSize) => this.RunTest<double>("double", 11, FlatBufferDeserializationOption.Greedy, offsetSize);
 
-        [Fact]
-        public void StructVector_InvalidType()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_InvalidType(int offsetSize)
         {
             string schema = $@"
             namespace StructVectorTests;
@@ -88,13 +110,14 @@ namespace FlatSharpTests.Compiler
             var ex = Assert.Throws<InvalidFbsFileException>(
                 () => FlatSharpCompiler.CompileAndLoadAssembly(
                     schema,
-                    new()));
+                    new() { OffsetSize = offsetSize }));
 
             Assert.Contains("Unable to resolve struct vector type 'Bar'.", ex.Message);
         }
 
-        [Fact]
-        public void StructVector_UnsafeVectorOnReferenceType()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_UnsafeVectorOnReferenceType(int offsetSize)
         {
             string schema = $@"
             namespace StructVectorTests;
@@ -111,8 +134,9 @@ namespace FlatSharpTests.Compiler
             Assert.Contains($"Field '__flatsharp__V_0' declares the '{MetadataKeys.UnsafeValueStructVector}' attribute. Unsafe struct vectors are only supported on value structs.", ex.Message);
         }
 
-        [Fact]
-        public void StructVector_NestedStruct()
+        [Theory]
+        [MemberData(nameof(OffsetSizes))]
+        public void StructVector_NestedStruct(int offsetSize)
         {
             int length = 7;
 
@@ -129,7 +153,7 @@ namespace FlatSharpTests.Compiler
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(
                 schema,
-                new());
+                new() { OffsetSize = offsetSize });
 
             Type tableType = asm.GetType("StructVectorTests.Table");
             Type fooType = asm.GetType("StructVectorTests.Foo");
@@ -191,7 +215,7 @@ namespace FlatSharpTests.Compiler
             }
         }
 
-        private void RunTest<T>(string fbsType, int length, FlatBufferDeserializationOption option) where T : struct
+        private void RunTest<T>(string fbsType, int length, FlatBufferDeserializationOption option, int offsetSize) where T : struct
         {
             string schema = $@"
             namespace StructVectorTests;
@@ -205,7 +229,7 @@ namespace FlatSharpTests.Compiler
 
             Assembly asm = FlatSharpCompiler.CompileAndLoadAssembly(
                 schema, 
-                new());
+                new() { OffsetSize = offsetSize });
 
             Type tableType = asm.GetType("StructVectorTests.Table");
             Type fooType = asm.GetType("StructVectorTests.Foo");

--- a/src/common.props
+++ b/src/common.props
@@ -8,9 +8,9 @@
   
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.7.1</Version>
+    <Version>5.7.2-pre-StirlingLabs</Version>
     <Version Condition=" '$(VersionMajor)' != '' ">$(VersionMajor)</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <AssemblyVersion>5.7.2</AssemblyVersion>
     <Authors>James Courtney</Authors>
     <Description>FlatSharp is an idiomatic implementation of the FlatBuffer binary format.</Description>
     <Copyright>2021</Copyright>


### PR DESCRIPTION
Implements a new component for type models, `OffsetModel` to allow varying offset and file identifier sizes.

Bumps Microsoft.CodeAnalysis.CSharp.Workspaces and Microsoft.Net.Compilers versions from 3.8.0 to 3.11.0.

VTable offset sizes are not parameterized yet.

Messages can be extremely short when 16 and 8-bit offset sizes are specified.

Messages can (obviously) contain a lot more data when 64-bit offset sizes are specified.

Implemented by compiler options, `--offset-size`, `--file-identifier-size` and `--strict-file-identifier-size`.

This will be tested for parity against flatcc built with non-standard offset sizes. (https://github.com/dvidelabs/flatcc/pull/206)

StirlingLabs have a fork of Google's FlatBuffers called BigBuffers which also aims for parity with flatcc with 64-bit offset sizes.

