### PR TITLE
More robust spawning of `flatc` with output handling

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -283,7 +283,7 @@ namespace FlatSharp.Compiler
                 "--bfbs-comments",
                 "--bfbs-builtins",
                 "--bfbs-filenames",
-                info.DirectoryName,
+                info.DirectoryName!, // Files always have a directory name, dammit!
                 "--no-warnings",
                 "-o",
                 outputDir,

--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -301,9 +301,9 @@ namespace FlatSharp.Compiler
 
                 void OnDataReceived(object sender, DataReceivedEventArgs args)
                 {
-                    if (args.Data is { } line)
+                    if (!string.IsNullOrEmpty(args.Data))
                     {
-                        lines.Add(line);
+                        lines.Add(args.Data);
                     }
                 }
 
@@ -322,7 +322,7 @@ namespace FlatSharp.Compiler
                 }
                 else
                 {
-                    foreach (var line in lines.Where(line => line.Length > 0))
+                    foreach (var line in lines)
                     {
                         ErrorContext.Current.RegisterError(line);
                     }

--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -302,7 +302,9 @@ namespace FlatSharp.Compiler
                 void OnDataReceived(object sender, DataReceivedEventArgs args)
                 {
                     if (args.Data is { } line)
+                    {
                         lines.Add(line);
+                    }
                 }
 
                 p.OutputDataReceived += OnDataReceived;
@@ -321,7 +323,9 @@ namespace FlatSharp.Compiler
                 else
                 {
                     foreach (var line in lines.Where(line => line.Length > 0))
+                    {
                         ErrorContext.Current.RegisterError(line);
+                    }
 
                     ErrorContext.Current.ThrowIfHasErrors();
                     throw new InvalidFbsFileException("Unknown error when invoking flatc. Process exited with error, but didn't write any errors.");


### PR DESCRIPTION
This PR addresses a number of robustness issues with spawning of `flatc` and harnessing its output. The changes can be summarised as follows:

- Better specification of command-line arguments as a list via `ArgumentList` so one doesn't have to worry about platform idiosyncrasies with respect to quoting, escaping and separating arguments (these are handled internally by `Process`).
- Asynchronous reading and collecting of redirected output & error streams to avoid potential for deadlocks.
- Disposing the spawned process via `using`.

All tests were passing locally with these changes.
