### PR TITLE
Binary Search Optimizations

### DIFF
--- a/src/Benchmarks/ExperimentalBenchmark/Benchmark.fbs
+++ b/src/Benchmarks/ExperimentalBenchmark/Benchmark.fbs
@@ -4,16 +4,14 @@ attribute "fs_nonVirtual";
 attribute "fs_valueStruct";
 attribute "fs_unsafeStructVector";
 attribute "fs_nonVirtual";
+attribute "fs_sortedVector";
 
 namespace BenchmarkCore;
 
-table ValueTable {
-	Points : [Vec3];
+table Table {
+    Items : [ VecTable ] (fs_sortedVector);
 }
 
-struct Vec3 (fs_nonVirtual)
-{
-	X : int;
-	Y : int;
-	Z : int;
+table VecTable {
+    Key : string (key);
 }

--- a/src/Benchmarks/ExperimentalBenchmark/ExperimentalBenchmark.csproj
+++ b/src/Benchmarks/ExperimentalBenchmark/ExperimentalBenchmark.csproj
@@ -1,41 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props" />
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <LangVersion>9.0</LangVersion>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <Nullable>annotations</Nullable>
-    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
-    <PackageReference Include="Grpc" Version="2.27.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\FlatSharp.Compiler\FlatSharp.Compiler.csproj" />
-    <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
-    <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Benchmark.fbs.generated.cs" />
-    <Compile Include="Benchmark.fbs.generated.cs" />
-  </ItemGroup>
-
-  <Target Name="FBS" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <FlatSharpCompilerDll>..\..\FlatSharp.Compiler\bin\$(Configuration)\$(TargetFramework)\FlatSharp.Compiler.dll</FlatSharpCompilerDll>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net6.0</TargetFrameworks>
+        <DelaySign>false</DelaySign>
+        <SignAssembly>false</SignAssembly>
     </PropertyGroup>
-    <Exec Command="dotnet $(FlatSharpCompilerDll) -i Benchmark.fbs -o . --nullable-warnings true" />
-  </Target>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
+        <PackageReference Include="Grpc" Version="2.27.0" />
+        <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\FlatSharp.Compiler\FlatSharp.Compiler.csproj" />
+        <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
+        <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Remove="Benchmark.fbs.generated.cs" />
+        <Compile Include="Benchmark.fbs.generated.cs" />
+    </ItemGroup>
+
+    <Target Name="FBS" BeforeTargets="CoreCompile">
+        <PropertyGroup>
+            <FlatSharpCompilerDll>..\..\FlatSharp.Compiler\bin\$(Configuration)\$(TargetFramework)\FlatSharp.Compiler.dll</FlatSharpCompilerDll>
+        </PropertyGroup>
+        <Exec Command="dotnet $(FlatSharpCompilerDll) -i Benchmark.fbs -o . --nullable-warnings true" />
+    </Target>
 </Project>

--- a/src/FlatSharp.Runtime/IFlatBufferDeserializedVector.cs
+++ b/src/FlatSharp.Runtime/IFlatBufferDeserializedVector.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Copyright 2021 James Courtney
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace FlatSharp;
+
+/// <summary>
+/// An interface implemented on buffer-backed Flatbuffer vectors. This interface is internal to FlatSharp and exposes some
+/// functionality to assist with binary searching.
+/// </summary>
+internal interface IFlatBufferDeserializedVector
+{
+    /// <summary>
+    /// Gets the input buffer.
+    /// </summary>
+    IInputBuffer InputBuffer { get; }
+
+    /// <summary>
+    /// Gets the raw item size of each element in the vector.
+    /// </summary>
+    int ItemSize { get; }
+
+    /// <summary>
+    /// The number of items.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Returns the absolute position in the Input Buffer of the given index in the vector.
+    /// </summary>
+    int OffsetOf(int index);
+
+    /// <summary>
+    /// Gets the item at the given index.
+    /// </summary>
+    object ItemAt(int index);
+}

--- a/src/FlatSharp.Runtime/SortedVectorHelpers.cs
+++ b/src/FlatSharp.Runtime/SortedVectorHelpers.cs
@@ -414,21 +414,18 @@ namespace FlatSharp
             int rightIndex,
             Span<(int, int, int)> keyOffsets) where TSpanComparer : ISpanComparer
         {
-            if (leftIndex != rightIndex)
+            (int leftOffset, int leftLength, _) = keyOffsets[leftIndex];
+            (int rightOffset, int rightLength, _) = keyOffsets[rightIndex];
+
+            bool leftExists = leftOffset != 0;
+            bool rightExists = rightOffset != 0;
+
+            var leftSpan = vector.Slice(leftOffset, leftLength);
+            var rightSpan = vector.Slice(rightOffset, rightLength);
+
+            if (comparer.Compare(leftExists, leftSpan, rightExists, rightSpan) > 0)
             {
-                (int leftOffset, int leftLength, _) = keyOffsets[leftIndex];
-                (int rightOffset, int rightLength, _) = keyOffsets[rightIndex];
-
-                bool leftExists = leftOffset != 0;
-                bool rightExists = rightOffset != 0;
-
-                var leftSpan = vector.Slice(leftOffset, leftLength);
-                var rightSpan = vector.Slice(rightOffset, rightLength);
-
-                if (comparer.Compare(leftExists, leftSpan, rightExists, rightSpan) > 0)
-                {
-                    SwapVectorPositions(leftIndex, rightIndex, keyOffsets);
-                }
+                SwapVectorPositions(leftIndex, rightIndex, keyOffsets);
             }
         }
 

--- a/src/FlatSharp.Runtime/SortedVectorHelpers.cs
+++ b/src/FlatSharp.Runtime/SortedVectorHelpers.cs
@@ -36,6 +36,7 @@ namespace FlatSharp
     using System.Buffers.Binary;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
     using FlatSharp.Attributes;
@@ -115,10 +116,7 @@ namespace FlatSharp
         public static TTable? BinarySearchByFlatBufferKey<TTable, TKey>(this IList<TTable> sortedVector, TKey key)
             where TTable : class
         {
-            if (key is null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            CheckKeyNotNull(key);
 
             if (key is string str)
             {
@@ -145,10 +143,7 @@ namespace FlatSharp
         public static TTable? BinarySearchByFlatBufferKey<TTable, TKey>(this TTable[] sortedVector, TKey key)
             where TTable : class
         {
-            if (key is null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            CheckKeyNotNull(key);
 
             if (key is string str)
             {
@@ -175,10 +170,7 @@ namespace FlatSharp
         public static TTable? BinarySearchByFlatBufferKey<TTable, TKey>(this IReadOnlyList<TTable> sortedVector, TKey key)
            where TTable : class
         {
-            if (key is null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            CheckKeyNotNull(key);
 
             if (key is string str)
             {
@@ -195,6 +187,14 @@ namespace FlatSharp
                     new ReadOnlyListIndexable<TTable, TKey>(sortedVector),
                     sortedVector,
                     new NaiveComparer<TKey>(key));
+            }
+        }
+
+        private static void CheckKeyNotNull<TKey>(TKey key)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
             }
         }
 
@@ -668,8 +668,10 @@ namespace FlatSharp
                 return Comparer<T>.Default.Compare(left, this.right);
             }
 
+            [ExcludeFromCodeCoverage]
             public void Dispose()
             {
+                // No-op.
             }
         }
 

--- a/src/FlatSharp.Runtime/Vectors/FlatBufferProgressiveVector.cs
+++ b/src/FlatSharp.Runtime/Vectors/FlatBufferProgressiveVector.cs
@@ -20,7 +20,6 @@ namespace FlatSharp
     using System.Collections;
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
 
     /// <summary>
@@ -28,7 +27,7 @@ namespace FlatSharp
     /// for data locality, random access, and reasonably low memory overhead.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class FlatBufferProgressiveVector<T, TInputBuffer> : IList<T>, IReadOnlyList<T>
+    public class FlatBufferProgressiveVector<T, TInputBuffer> : IList<T>, IReadOnlyList<T>, IFlatBufferDeserializedVector
         where T : notnull
         where TInputBuffer : IInputBuffer
     {
@@ -96,6 +95,15 @@ namespace FlatSharp
         public int Count { get; }
 
         public bool IsReadOnly => true;
+
+        IInputBuffer IFlatBufferDeserializedVector.InputBuffer => ((IFlatBufferDeserializedVector)this.innerVector).InputBuffer;
+
+        int IFlatBufferDeserializedVector.ItemSize => ((IFlatBufferDeserializedVector)this.innerVector).ItemSize;
+
+        int IFlatBufferDeserializedVector.OffsetOf(int index) => ((IFlatBufferDeserializedVector)this.innerVector).OffsetOf(index);
+
+        object IFlatBufferDeserializedVector.ItemAt(int index) => this[index]!;
+
         public void Add(T item)
         {
             throw new NotMutableException("FlatBufferVector does not allow adding items.");

--- a/src/FlatSharp.Runtime/Vectors/FlatBufferVector.cs
+++ b/src/FlatSharp.Runtime/Vectors/FlatBufferVector.cs
@@ -21,7 +21,7 @@ namespace FlatSharp
     /// <summary>
     /// A base flat buffer vector for non-unions.
     /// </summary>
-    public abstract class FlatBufferVector<T, TInputBuffer> : FlatBufferVectorBase<T, TInputBuffer>
+    public abstract class FlatBufferVector<T, TInputBuffer> : FlatBufferVectorBase<T, TInputBuffer>, IFlatBufferDeserializedVector
         where TInputBuffer : IInputBuffer
     {
         private readonly int offset;
@@ -60,9 +60,25 @@ namespace FlatSharp
             }
         }
 
+        IInputBuffer IFlatBufferDeserializedVector.InputBuffer => this.memory;
+
+        int IFlatBufferDeserializedVector.ItemSize => this.itemSize;
+
+        int IFlatBufferDeserializedVector.OffsetOf(int index)
+        {
+            if ((uint)index >= this.Count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return checked(this.offset + (this.itemSize * index));
+        }
+
+        object IFlatBufferDeserializedVector.ItemAt(int index) => this[index]!;
+
         protected override void ParseItem(int index, out T item)
         {
-            int offset = checked(this.offset + (itemSize * index));
+            int offset = checked(this.offset + (this.itemSize * index));
             this.ParseItem(this.memory, offset, this.fieldContext, out item);
         }
 

--- a/src/FlatSharp.Runtime/Vectors/FlatBufferVector.cs
+++ b/src/FlatSharp.Runtime/Vectors/FlatBufferVector.cs
@@ -66,11 +66,7 @@ namespace FlatSharp
 
         int IFlatBufferDeserializedVector.OffsetOf(int index)
         {
-            if ((uint)index >= this.Count)
-            {
-                throw new IndexOutOfRangeException();
-            }
-
+            this.CheckIndex(index);
             return checked(this.offset + (this.itemSize * index));
         }
 

--- a/src/FlatSharp.Runtime/Vectors/FlatBufferVectorBase.cs
+++ b/src/FlatSharp.Runtime/Vectors/FlatBufferVectorBase.cs
@@ -47,11 +47,7 @@ namespace FlatSharp
         {
             get
             {
-                if ((uint)index >= this.Count)
-                {
-                    throw new IndexOutOfRangeException();
-                }
-
+                this.CheckIndex(index);
                 this.ParseItem(index, out T item);
                 return item;
             }
@@ -160,6 +156,14 @@ namespace FlatSharp
         }
 
         protected abstract void ParseItem(int index, out T item);
+
+        protected void CheckIndex(int index)
+        {
+            if ((uint)index >= this.Count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
 
         public void Add(T item)
         {

--- a/src/FlatSharp.Runtime/Vectors/IndexedVector.cs
+++ b/src/FlatSharp.Runtime/Vectors/IndexedVector.cs
@@ -35,7 +35,7 @@ namespace FlatSharp
 
         static IndexedVector()
         {
-            KeyGetter = SortedVectorHelpers.GetOrCreateGetKeyCallback<TValue, TKey>();
+            KeyGetter = SortedVectorHelpers.KeyLookup<TValue, TKey>.KeyGetter;
         }
 
         public IndexedVector()

--- a/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
+++ b/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
@@ -398,7 +398,7 @@ namespace FlatSharp
         private static string GetAggressiveInliningAttribute()
         {
             string inlining = "System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining";
-            string attribute = $"[{typeof(System.Runtime.CompilerServices.MethodImplAttribute).FullName}({inlining})]";
+            string attribute = $"[{typeof(MethodImplAttribute).FullName}({inlining})]";
             return attribute;
         }
 

--- a/src/Tests/Coverage/Coverage.csproj
+++ b/src/Tests/Coverage/Coverage.csproj
@@ -39,7 +39,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\FlatSharp.Compiler\FlatSharp.Compiler.csproj" />
     <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
-    <ProjectReference Include="..\..\FlatSharp.Unsafe\FlatSharp.Unsafe.csproj" />
     <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" />
     <ProjectReference Include="..\..\Google.FlatBuffers\Google.FlatBuffers.csproj" />
   </ItemGroup>

--- a/src/Tests/FlatSharpTests/OracleTests/OracleDeserializeTests.cs
+++ b/src/Tests/FlatSharpTests/OracleTests/OracleDeserializeTests.cs
@@ -385,8 +385,10 @@
             Assert.Equal("foobar", str);
         }
 
-        [Fact]
-        public void SortedVectors()
+        [Theory]
+        [InlineData(FlatBufferDeserializationOption.Greedy)]
+        [InlineData(FlatBufferDeserializationOption.Lazy)]
+        public void SortedVectors(FlatBufferDeserializationOption option)
         {
             var builder = new FlatBuffers.FlatBufferBuilder(1024 * 1024);
 
@@ -432,7 +434,8 @@
             builder.Finish(table.Value);
             byte[] serialized = builder.SizedByteArray();
 
-            var parsed = FlatBufferSerializer.Default.Parse<SortedVectorTest<SortedVectorItem<int>>>(serialized);
+            var serializer = new FlatBufferSerializer(option);
+            var parsed = serializer.Parse<SortedVectorTest<SortedVectorItem<int>>>(serialized);
 
             VerifySorted(parsed.StringVector, new Utf8StringComparer(), strings, new List<string> { Guid.NewGuid().ToString(), "banana" });
             VerifySorted(parsed.IntVector, Comparer<int>.Default, ints, new List<int> { -1, -3, 0 });

--- a/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -584,7 +584,7 @@ namespace FlatSharpTests
             public void Test() => this.SortedVectorTest<string>(
                 rng =>
                 {
-                    int length = rng.Next(0, 30);
+                    int length = rng.Next(0, 2048);
                     byte[] data = new byte[length];
                     rng.NextBytes(data);
                     return Convert.ToBase64String(data);

--- a/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -13,79 +13,99 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using FlatSharp;
+using FlatSharp.Attributes;
+using Xunit;
 
-namespace FlatSharpTests
+namespace FlatSharpTests;
+
+/// <summary>
+/// Binary format testing for vector serialization.
+/// </summary>
+
+public class VectorSerializationTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.IO;
-    using System.Linq;
-    using System.Runtime.InteropServices;
-    using System.Text;
-    using FlatSharp;
-    using FlatSharp.Attributes;
-    using Xunit;
+    private static readonly Dictionary<FlatBufferDeserializationOption, FlatBufferSerializer> SerializerLookup;
 
-    /// <summary>
-    /// Binary format testing for vector serialization.
-    /// </summary>
-
-    public class VectorSerializationTests
+    static VectorSerializationTests()
     {
-        private static readonly Dictionary<FlatBufferDeserializationOption, FlatBufferSerializer> SerializerLookup;
-
-        static VectorSerializationTests()
+        SerializerLookup = new();
+        foreach (FlatBufferDeserializationOption option in Enum.GetValues(typeof(FlatBufferDeserializationOption)))
         {
-            SerializerLookup = new();
-            foreach (FlatBufferDeserializationOption option in Enum.GetValues(typeof(FlatBufferDeserializationOption)))
+            SerializerLookup[option] = new FlatBufferSerializer(option);
+        }
+    }
+
+    public class SimpleTests
+    {
+        [Fact]
+        public void EmptyString()
+        {
+            var root = new RootTable<string>
             {
-                SerializerLookup[option] = new FlatBufferSerializer(option);
-            }
+                Vector = string.Empty,
+            };
+
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
+
+            byte[] expectedResult =
+            {
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to string
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                0, 0, 0, 0,          // vector length
+                0,                   // null terminator (special case for strings).
+            };
+
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
         }
 
-        public class SimpleTests
+        [Fact]
+        public void SimpleString()
         {
-            [Fact]
-            public void EmptyString()
+            var root = new RootTable<string>
             {
-                var root = new RootTable<string>
-                {
-                    Vector = string.Empty,
-                };
+                Vector = new string(new char[] { (char)1, (char)2, (char)3 }),
+            };
 
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
 
-                byte[] expectedResult =
-                {
-                    4, 0, 0, 0,          // offset to table start
-                    248, 255, 255, 255,  // soffset to vtable (-8)
-                    12, 0, 0, 0,         // uoffset_t to string
-                    6, 0,                // vtable length
-                    8, 0,                // table length
-                    4, 0,                // offset of index 0 field
-                    0, 0,                // padding to 4-byte alignment
-                    0, 0, 0, 0,          // vector length
-                    0,                   // null terminator (special case for strings).
-                };
-
-                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-            }
-
-            [Fact]
-            public void SimpleString()
+            byte[] expectedResult =
             {
-                var root = new RootTable<string>
-                {
-                    Vector = new string(new char[] { (char)1, (char)2, (char)3 }),
-                };
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
+                1, 2, 3, 0,          // data + null terminator (special case for string vectors).
+            };
 
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
 
+        [Fact]
+        public void Simple_Scalar_Vectors()
+        {
+            static void Test<T>(Func<byte[], T> factory)
+            {
                 byte[] expectedResult =
                 {
                     4, 0, 0, 0,          // offset to table start
@@ -96,156 +116,135 @@ namespace FlatSharpTests
                     4, 0,                // offset of index 0 field
                     0, 0,                // padding to 4-byte alignment
                     3, 0, 0, 0,          // vector length
-                    1, 2, 3, 0,          // data + null terminator (special case for string vectors).
+
+                    // vector data
+                    1, 2, 3,
                 };
+
+                var root = new RootTable<T>
+                {
+                    Vector = factory(new byte[] { 1, 2, 3 })
+                };
+
+                Span<byte> target = new byte[1024];
+                int offset = FlatBufferSerializer.Default.Serialize(root, target);
+                string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
+
+                target = target.Slice(0, offset);
 
                 Assert.True(expectedResult.AsSpan().SequenceEqual(target));
             }
 
-            [Fact]
-            public void Simple_Scalar_Vectors()
+            Test<IList<byte>>(a => a.ToList());
+            Test<IReadOnlyList<byte>>(a => a.ToList());
+            Test<byte[]>(a => a);
+            Test<Memory<byte>>(a => a.AsMemory());
+            Test<ReadOnlyMemory<byte>>(a => a.AsMemory());
+            Test<Memory<byte>?>(a => a.AsMemory());
+            Test<ReadOnlyMemory<byte>?>(a => a.AsMemory());
+        }
+
+        [Fact]
+        public void Empty_Vectors()
+        {
+            static void Test<T>(T instance)
             {
-                static void Test<T>(Func<byte[], T> factory)
-                {
-                    byte[] expectedResult =
-                    {
-                        4, 0, 0, 0,          // offset to table start
-                        248, 255, 255, 255,  // soffset to vtable (-8)
-                        12, 0, 0, 0,         // uoffset_t to vector
-                        6, 0,                // vtable length
-                        8, 0,                // table length
-                        4, 0,                // offset of index 0 field
-                        0, 0,                // padding to 4-byte alignment
-                        3, 0, 0, 0,          // vector length
-
-                        // vector data
-                        1, 2, 3,
-                    };
-
-                    var root = new RootTable<T>
-                    {
-                        Vector = factory(new byte[] { 1, 2, 3 })
-                    };
-
-                    Span<byte> target = new byte[1024];
-                    int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                    string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
-
-                    target = target.Slice(0, offset);
-
-                    Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-                }
-
-                Test<IList<byte>>(a => a.ToList());
-                Test<IReadOnlyList<byte>>(a => a.ToList());
-                Test<byte[]>(a => a);
-                Test<Memory<byte>>(a => a.AsMemory());
-                Test<ReadOnlyMemory<byte>>(a => a.AsMemory());
-                Test<Memory<byte>?>(a => a.AsMemory());
-                Test<ReadOnlyMemory<byte>?>(a => a.AsMemory());
-            }
-
-            [Fact]
-            public void Empty_Vectors()
-            {
-                static void Test<T>(T instance)
-                {
-                    byte[] expectedResult =
-                    {
-                        4, 0, 0, 0,          // offset to table start
-                        248, 255, 255, 255,  // soffset to vtable (-8)
-                        12, 0, 0, 0,         // uoffset_t to vector
-                        6, 0,                // vtable length
-                        8, 0,                // table length
-                        4, 0,                // offset of index 0 field
-                        0, 0,                // padding to 4-byte alignment
-                        0, 0, 0, 0,          // vector length
-                    };
-
-                    var root = new RootTable<T>
-                    {
-                        Vector = instance
-                    };
-
-                    Span<byte> target = new byte[1024];
-                    int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                    string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
-
-                    target = target.Slice(0, offset);
-
-                    Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-                }
-
-                Test<IList<int>>(new List<int>());
-                Test<IReadOnlyList<int>>(new List<int>());
-                Test<int[]>(new int[0]);
-                Test<Memory<byte>>(new Memory<byte>(new byte[0]));
-                Test<ReadOnlyMemory<byte>>(new ReadOnlyMemory<byte>(new byte[0]));
-                Test<Memory<byte>?>(new Memory<byte>(new byte[0]));
-                Test<ReadOnlyMemory<byte>?>(new ReadOnlyMemory<byte>(new byte[0]));
-                Test<IIndexedVector<string, TableWithKey<string>>>(new IndexedVector<string, TableWithKey<string>>());
-            }
-
-            [Fact]
-            public void Null_Vectors()
-            {
-                static void Test<T>()
-                {
-                    byte[] expectedResult =
-                    {
-                        4, 0, 0, 0,      // offset to table start
-                        252,255,255,255, // soffset to vtable (-4)
-                        4, 0,            // vtable length
-                        4, 0,            // table length
-                    };
-
-                    var root = new RootTable<T>
-                    {
-                        Vector = default(T)
-                    };
-
-                    Span<byte> target = new byte[1024];
-                    int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                    string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
-
-                    target = target.Slice(0, offset);
-
-                    Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-                }
-
-                Test<IList<int>>();
-                Test<IReadOnlyList<int>>();
-                Test<int[]>();
-                Test<Memory<byte>?>();
-                Test<ReadOnlyMemory<byte>?>();
-                Test<IIndexedVector<string, TableWithKey<string>>>();
-
-                Test<FlatBufferUnion<string>[]>();
-                Test<IList<FlatBufferUnion<string>>>();
-                Test<IReadOnlyList<FlatBufferUnion<string>>>();
-
-                Test<string>();
-            }
-
-            [Fact]
-            public void UnalignedStruct_5Byte()
-            {
-                var root = new RootTable<FiveByteStruct[]>
-                {
-                    Vector = new[]
-                    {
-                        new FiveByteStruct { Byte = 1, Int = 1 },
-                        new FiveByteStruct { Byte = 2, Int = 2 },
-                        new FiveByteStruct { Byte = 3, Int = 3 },
-                    },
-                };
-
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
-
                 byte[] expectedResult =
                 {
+                    4, 0, 0, 0,          // offset to table start
+                    248, 255, 255, 255,  // soffset to vtable (-8)
+                    12, 0, 0, 0,         // uoffset_t to vector
+                    6, 0,                // vtable length
+                    8, 0,                // table length
+                    4, 0,                // offset of index 0 field
+                    0, 0,                // padding to 4-byte alignment
+                    0, 0, 0, 0,          // vector length
+                };
+
+                var root = new RootTable<T>
+                {
+                    Vector = instance
+                };
+
+                Span<byte> target = new byte[1024];
+                int offset = FlatBufferSerializer.Default.Serialize(root, target);
+                string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
+
+                target = target.Slice(0, offset);
+
+                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+            }
+
+            Test<IList<int>>(new List<int>());
+            Test<IReadOnlyList<int>>(new List<int>());
+            Test<int[]>(new int[0]);
+            Test<Memory<byte>>(new Memory<byte>(new byte[0]));
+            Test<ReadOnlyMemory<byte>>(new ReadOnlyMemory<byte>(new byte[0]));
+            Test<Memory<byte>?>(new Memory<byte>(new byte[0]));
+            Test<ReadOnlyMemory<byte>?>(new ReadOnlyMemory<byte>(new byte[0]));
+            Test<IIndexedVector<string, TableWithKey<string>>>(new IndexedVector<string, TableWithKey<string>>());
+        }
+
+        [Fact]
+        public void Null_Vectors()
+        {
+            static void Test<T>()
+            {
+                byte[] expectedResult =
+                {
+                    4, 0, 0, 0,      // offset to table start
+                    252,255,255,255, // soffset to vtable (-4)
+                    4, 0,            // vtable length
+                    4, 0,            // table length
+                };
+
+                var root = new RootTable<T>
+                {
+                    Vector = default(T)
+                };
+
+                Span<byte> target = new byte[1024];
+                int offset = FlatBufferSerializer.Default.Serialize(root, target);
+                string csharp = FlatBufferSerializer.Default.Compile(root).CSharp;
+
+                target = target.Slice(0, offset);
+
+                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+            }
+
+            Test<IList<int>>();
+            Test<IReadOnlyList<int>>();
+            Test<int[]>();
+            Test<Memory<byte>?>();
+            Test<ReadOnlyMemory<byte>?>();
+            Test<IIndexedVector<string, TableWithKey<string>>>();
+
+            Test<FlatBufferUnion<string>[]>();
+            Test<IList<FlatBufferUnion<string>>>();
+            Test<IReadOnlyList<FlatBufferUnion<string>>>();
+
+            Test<string>();
+        }
+
+        [Fact]
+        public void UnalignedStruct_5Byte()
+        {
+            var root = new RootTable<FiveByteStruct[]>
+            {
+                Vector = new[]
+                {
+                    new FiveByteStruct { Byte = 1, Int = 1 },
+                    new FiveByteStruct { Byte = 2, Int = 2 },
+                    new FiveByteStruct { Byte = 3, Int = 3 },
+                },
+            };
+
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
+
+            byte[] expectedResult =
+            {
                 4, 0, 0, 0,          // offset to table start
                 248, 255, 255, 255,  // soffset to vtable (-8)
                 12, 0, 0, 0,         // uoffset_t to vector
@@ -265,214 +264,214 @@ namespace FlatSharpTests
                 0, 0, 0,             // padding
             };
 
-                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-            }
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
 
-            [Fact]
-            public void UnalignedStruct_Value5Byte()
+        [Fact]
+        public void UnalignedStruct_Value5Byte()
+        {
+            var root = new RootTable<ValueFiveByteStruct[]>
             {
-                var root = new RootTable<ValueFiveByteStruct[]>
+                Vector = new[]
                 {
-                    Vector = new[]
-                    {
-                        new ValueFiveByteStruct { Byte = 1, Int = 1 },
-                        new ValueFiveByteStruct { Byte = 2, Int = 2 },
-                        new ValueFiveByteStruct { Byte = 3, Int = 3 },
-                    },
-                };
+                    new ValueFiveByteStruct { Byte = 1, Int = 1 },
+                    new ValueFiveByteStruct { Byte = 2, Int = 2 },
+                    new ValueFiveByteStruct { Byte = 3, Int = 3 },
+                },
+            };
 
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
 
-                byte[] expectedResult =
-                {
-                    4, 0, 0, 0,          // offset to table start
-                    248, 255, 255, 255,  // soffset to vtable (-8)
-                    12, 0, 0, 0,         // uoffset_t to vector
-                    6, 0,                // vtable length
-                    8, 0,                // table length
-                    4, 0,                // offset of index 0 field
-                    0, 0,                // padding to 4-byte alignment
-                    3, 0, 0, 0,          // vector length
-                    1, 0, 0, 0,          // index 0.Int
-                    1,                   // index 0.Byte
-                    0, 0, 0,             // padding
-                    2, 0, 0, 0,          // index 1.Int
-                    2,                   // index 1.Byte
-                    0, 0, 0,             // padding
-                    3, 0, 0, 0,          // index2.Int
-                    3,                   // Index2.byte
-                    0, 0, 0,             // padding
-                };
-
-                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-            }
-
-            [Fact]
-            public void UnalignedStruct_9Byte()
+            byte[] expectedResult =
             {
-                var root = new RootTable2<NineByteStruct[]>
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
+                1, 0, 0, 0,          // index 0.Int
+                1,                   // index 0.Byte
+                0, 0, 0,             // padding
+                2, 0, 0, 0,          // index 1.Int
+                2,                   // index 1.Byte
+                0, 0, 0,             // padding
+                3, 0, 0, 0,          // index2.Int
+                3,                   // Index2.byte
+                0, 0, 0,             // padding
+            };
+
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
+
+        [Fact]
+        public void UnalignedStruct_9Byte()
+        {
+            var root = new RootTable2<NineByteStruct[]>
+            {
+                Vector = new[]
                 {
-                    Vector = new[]
-                    {
                     new NineByteStruct { Byte = 1, Long = 1 },
                     new NineByteStruct { Byte = 2, Long = 2 },
                 },
-                };
+            };
 
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
 
-                byte[] expectedResult =
-                {
-                    4, 0, 0, 0,                     // offset to table start
-                    246, 255, 255, 255,             // soffset to vtable (-10)
-                    20, 0, 0, 0,                    // uoffset_t to vector
-                    0,                              // alignment imp
-                    0,                              // padding
-                    8, 0,                           // vtable length
-                    9, 0,                           // table length
-                    8, 0,                           // offset to index 0 field
-                    4, 0,                           // offset of index 1 field
-
-                    0, 0, 0, 0, 0, 0,               // padding to 8 byte alignment for struct.
-                    2, 0, 0, 0,                     // vector length
-                    1, 0, 0, 0, 0, 0, 0, 0,         // index 0.Long
-                    1,                              // index 0.Byte
-                    0, 0, 0, 0, 0, 0, 0,            // padding
-                    2, 0, 0, 0, 0, 0, 0, 0,         // index 1.Long
-                    2,                              // index 1.Byte
-                    0, 0, 0, 0, 0, 0, 0,            // padding
-                };
-
-                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-            }
-
-            [Fact]
-            public void UnalignedStruct_Value9Byte()
+            byte[] expectedResult =
             {
-                var root = new RootTable2<ValueNineByteStruct[]>
+                4, 0, 0, 0,                     // offset to table start
+                246, 255, 255, 255,             // soffset to vtable (-10)
+                20, 0, 0, 0,                    // uoffset_t to vector
+                0,                              // alignment imp
+                0,                              // padding
+                8, 0,                           // vtable length
+                9, 0,                           // table length
+                8, 0,                           // offset to index 0 field
+                4, 0,                           // offset of index 1 field
+
+                0, 0, 0, 0, 0, 0,               // padding to 8 byte alignment for struct.
+                2, 0, 0, 0,                     // vector length
+                1, 0, 0, 0, 0, 0, 0, 0,         // index 0.Long
+                1,                              // index 0.Byte
+                0, 0, 0, 0, 0, 0, 0,            // padding
+                2, 0, 0, 0, 0, 0, 0, 0,         // index 1.Long
+                2,                              // index 1.Byte
+                0, 0, 0, 0, 0, 0, 0,            // padding
+            };
+
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
+
+        [Fact]
+        public void UnalignedStruct_Value9Byte()
+        {
+            var root = new RootTable2<ValueNineByteStruct[]>
+            {
+                Vector = new[]
                 {
-                    Vector = new[]
-                    {
                     new ValueNineByteStruct { Byte = 1, Long = 1 },
                     new ValueNineByteStruct { Byte = 2, Long = 2 },
                 },
-                };
+            };
 
-                Span<byte> target = new byte[10240];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                target = target.Slice(0, offset);
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.Default.Serialize(root, target);
+            target = target.Slice(0, offset);
 
-                byte[] expectedResult =
-                {
-                    4, 0, 0, 0,                     // offset to table start
-                    246, 255, 255, 255,             // soffset to vtable (-10)
-                    20, 0, 0, 0,                    // uoffset_t to vector
-                    0,                              // alignment imp
-                    0,                              // padding
-                    8, 0,                           // vtable length
-                    9, 0,                           // table length
-                    8, 0,                           // offset to index 0 field
-                    4, 0,                           // offset of index 1 field
-
-                    0, 0, 0, 0, 0, 0,               // padding to 8 byte alignment for struct.
-                    2, 0, 0, 0,                     // vector length
-                    1, 0, 0, 0, 0, 0, 0, 0,         // index 0.Long
-                    1,                              // index 0.Byte
-                    0, 0, 0, 0, 0, 0, 0,            // padding
-                    2, 0, 0, 0, 0, 0, 0, 0,         // index 1.Long
-                    2,                              // index 1.Byte
-                    0, 0, 0, 0, 0, 0, 0,            // padding
-                };
-
-                Assert.True(expectedResult.AsSpan().SequenceEqual(target));
-            }
-
-            [Fact]
-            public void NullStringInVector()
+            byte[] expectedResult =
             {
-                var root = new RootTable<IList<string>>
-                {
-                    Vector = new string[] { "foobar", "banana", null, "two" },
-                };
+                4, 0, 0, 0,                     // offset to table start
+                246, 255, 255, 255,             // soffset to vtable (-10)
+                20, 0, 0, 0,                    // uoffset_t to vector
+                0,                              // alignment imp
+                0,                              // padding
+                8, 0,                           // vtable length
+                9, 0,                           // table length
+                8, 0,                           // offset to index 0 field
+                4, 0,                           // offset of index 1 field
 
-                var serializer = FlatBufferSerializer.Default.Compile<RootTable<IList<string>>>();
+                0, 0, 0, 0, 0, 0,               // padding to 8 byte alignment for struct.
+                2, 0, 0, 0,                     // vector length
+                1, 0, 0, 0, 0, 0, 0, 0,         // index 0.Long
+                1,                              // index 0.Byte
+                0, 0, 0, 0, 0, 0, 0,            // padding
+                2, 0, 0, 0, 0, 0, 0, 0,         // index 1.Long
+                2,                              // index 1.Byte
+                0, 0, 0, 0, 0, 0, 0,            // padding
+            };
 
-                byte[] target = new byte[10240];
-                Assert.Throws<InvalidDataException>(() => FlatBufferSerializer.Default.Serialize(root, target));
-            }
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
 
-            [Fact]
-            public void NullStructInVector()
+        [Fact]
+        public void NullStringInVector()
+        {
+            var root = new RootTable<IList<string>>
             {
-                var root = new RootTable<IList<Struct>>
-                {
-                    Vector = new[] { new Struct { Integer = 1, }, null, new Struct { Integer = 3 } },
-                };
+                Vector = new string[] { "foobar", "banana", null, "two" },
+            };
 
-                var serializer = FlatBufferSerializer.Default.Compile<RootTable<IList<Struct>>>();
+            var serializer = FlatBufferSerializer.Default.Compile<RootTable<IList<string>>>();
 
-                byte[] target = new byte[10240];
-                Assert.Throws<InvalidDataException>(() => FlatBufferSerializer.Default.Serialize(root, target));
-            }
+            byte[] target = new byte[10240];
+            Assert.Throws<InvalidDataException>(() => FlatBufferSerializer.Default.Serialize(root, target));
+        }
 
-            [Fact]
-            public void AlignedStructVectorMaxSize()
+        [Fact]
+        public void NullStructInVector()
+        {
+            var root = new RootTable<IList<Struct>>
             {
-                var root = new RootTable<IList<Struct>>();
+                Vector = new[] { new Struct { Integer = 1, }, null, new Struct { Integer = 3 } },
+            };
 
-                // Empty table max size (vector not included here).
-                var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+            var serializer = FlatBufferSerializer.Default.Compile<RootTable<IList<Struct>>>();
 
-                root.Vector = new[] { new Struct { Integer = 1 }, new Struct { Integer = 2 } };
+            byte[] target = new byte[10240];
+            Assert.Throws<InvalidDataException>(() => FlatBufferSerializer.Default.Serialize(root, target));
+        }
 
-                var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+        [Fact]
+        public void AlignedStructVectorMaxSize()
+        {
+            var root = new RootTable<IList<Struct>>();
 
-                // padding + length + padding + 2 * itemLength
-                Assert.Equal(3 + 4 + 3 + (2 * 4), maxSize - baselineMaxSize);
-            }
+            // Empty table max size (vector not included here).
+            var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
 
-            [Fact]
-            public void UnalignedStruct_5Byte_VectorMaxSize()
-            {
-                var root = new RootTable<IList<FiveByteStruct>>();
+            root.Vector = new[] { new Struct { Integer = 1 }, new Struct { Integer = 2 } };
 
-                // Empty table max size (vector not included here).
-                var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+            var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
 
-                root.Vector = new[] { new FiveByteStruct { Int = 1 }, new FiveByteStruct { Int = 2 } };
+            // padding + length + padding + 2 * itemLength
+            Assert.Equal(3 + 4 + 3 + (2 * 4), maxSize - baselineMaxSize);
+        }
 
-                var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+        [Fact]
+        public void UnalignedStruct_5Byte_VectorMaxSize()
+        {
+            var root = new RootTable<IList<FiveByteStruct>>();
 
-                // padding + length + padding to 4 byte alignment + (2 * (padding + itemLength))
-                Assert.Equal(3 + 4 + 3 + (2 * (3 + 5)), maxSize - baselineMaxSize);
-            }
+            // Empty table max size (vector not included here).
+            var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
 
-            [Fact]
-            public void UnalignedStruct_9Byte_VectorMaxSize()
-            {
-                var root = new RootTable<IList<NineByteStruct>>();
+            root.Vector = new[] { new FiveByteStruct { Int = 1 }, new FiveByteStruct { Int = 2 } };
 
-                // Empty table max size (vector not included here).
-                var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+            var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
 
-                root.Vector = new[] { new NineByteStruct { Long = 1 }, new NineByteStruct { Long = 2 } };
+            // padding + length + padding to 4 byte alignment + (2 * (padding + itemLength))
+            Assert.Equal(3 + 4 + 3 + (2 * (3 + 5)), maxSize - baselineMaxSize);
+        }
 
-                var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+        [Fact]
+        public void UnalignedStruct_9Byte_VectorMaxSize()
+        {
+            var root = new RootTable<IList<NineByteStruct>>();
 
-                // padding + length + padding to 8 byte alignment + (2 * (padding + itemLength))
-                Assert.Equal(3 + 4 + 7 + (2 * (7 + 9)), maxSize - baselineMaxSize);
-            }
+            // Empty table max size (vector not included here).
+            var baselineMaxSize = FlatBufferSerializer.Default.GetMaxSize(root);
 
-            [Fact]
-            public void SortedVector_StringKey()
-            {
-                var root = new RootTableSorted<IList<TableWithKey<string>>>();
+            root.Vector = new[] { new NineByteStruct { Long = 1 }, new NineByteStruct { Long = 2 } };
 
-                root.Vector = new List<TableWithKey<string>>
+            var maxSize = FlatBufferSerializer.Default.GetMaxSize(root);
+
+            // padding + length + padding to 8 byte alignment + (2 * (padding + itemLength))
+            Assert.Equal(3 + 4 + 7 + (2 * (7 + 9)), maxSize - baselineMaxSize);
+        }
+
+        [Fact]
+        public void SortedVector_StringKey()
+        {
+            var root = new RootTableSorted<IList<TableWithKey<string>>>();
+
+            root.Vector = new List<TableWithKey<string>>
             {
                 new TableWithKey<string> { Key = "d", Value = "0" },
                 new TableWithKey<string> { Key = "c", Value = "1" },
@@ -481,508 +480,574 @@ namespace FlatSharpTests
                 new TableWithKey<string> { Key = "", Value = "4" },
             };
 
-                byte[] data = new byte[1024];
-                FlatBufferSerializer.Default.Serialize(root, data);
+            byte[] data = new byte[1024];
+            FlatBufferSerializer.Default.Serialize(root, data);
 
-                var parsed = FlatBufferSerializer.Default.Parse<RootTableSorted<IList<TableWithKey<string>>>>(data);
+            var parsed = FlatBufferSerializer.Default.Parse<RootTableSorted<IList<TableWithKey<string>>>>(data);
 
-                Assert.Equal("", parsed.Vector[0].Key);
-                Assert.Equal("a", parsed.Vector[1].Key);
-                Assert.Equal("b", parsed.Vector[2].Key);
-                Assert.Equal("c", parsed.Vector[3].Key);
-                Assert.Equal("d", parsed.Vector[4].Key);
-            }
+            Assert.Equal("", parsed.Vector[0].Key);
+            Assert.Equal("a", parsed.Vector[1].Key);
+            Assert.Equal("b", parsed.Vector[2].Key);
+            Assert.Equal("c", parsed.Vector[3].Key);
+            Assert.Equal("d", parsed.Vector[4].Key);
+        }
 
-            [Fact]
-            public void SortedVector_StringKey_Null()
+        [Fact]
+        public void SortedVector_BinarySearch_ErrorCases()
+        {
+            IList<TableWithKey<string>> testList = new List<TableWithKey<string>>
             {
-                var root = new RootTableSorted<IList<TableWithKey<string>>>();
+                new TableWithKey<string> { Key = null, Value = "0" },
+                new TableWithKey<string> { Key = "notnull", Value = "3" },
+                new TableWithKey<string> { Key = "alsonotnull", Value = "3" },
+            };
 
-                root.Vector = new List<TableWithKey<string>>
+            var root = new RootTable<IList<TableWithKey<string>>>()
+            {
+                Vector = testList
+            };
+
+            byte[] data = new byte[1024];
+
+            // Serialize succeeds here because the "root" is unsorted.
+            FlatBufferSerializer.Default.Serialize(root, data);
+
+            // Fail to serialize sorted vector due to null key.
+            // Fail to search through greedy sorted vector due to null key.
+            {
+                var rootSorted = new RootTableSorted<IList<TableWithKey<string>>>()
                 {
-                    new TableWithKey<string> { Key = null, Value = "0" },
-                    new TableWithKey<string> { Key = "notnull", Value = "3" },
-                    new TableWithKey<string> { Key = "alsonotnull", Value = "3" },
+                    Vector = testList
                 };
 
-                byte[] data = new byte[1024];
-                Assert.Throws<InvalidOperationException>(() => FlatBufferSerializer.Default.Serialize(root, data));
-                Assert.Throws<InvalidOperationException>(() => root.Vector.BinarySearchByFlatBufferKey("AAA"));
-                Assert.Throws<InvalidOperationException>(() => root.Vector.BinarySearchByFlatBufferKey(3));
-                Assert.Throws<ArgumentNullException>(() => root.Vector.BinarySearchByFlatBufferKey((string)null));
+                var parsed_greedy = FlatBufferSerializer.Default.Parse<RootTableSorted<TableWithKey<string>[]>>(data);
+                Assert.Throws<InvalidOperationException>(() => FlatBufferSerializer.Default.Serialize(rootSorted, new byte[1024]));
+                Assert.Throws<InvalidOperationException>(() => parsed_greedy.Vector.BinarySearchByFlatBufferKey("AAA"));
+                Assert.Throws<InvalidOperationException>(() => parsed_greedy.Vector.BinarySearchByFlatBufferKey(3));
+                Assert.Throws<ArgumentNullException>(() => parsed_greedy.Vector.BinarySearchByFlatBufferKey((string)null));
+            }
+
+            // Fail to binary search through lazy sorted vector with null key.
+            {
+                // Serialize succeeds here because the "root" is unsorted.
+                FlatBufferSerializer.Default.Serialize(root, data);
+                var lazyCopy = SerializerLookup[FlatBufferDeserializationOption.Lazy].Parse<RootTable<IList<TableWithKey<string>>>>(data);
+
+                Assert.Throws<InvalidOperationException>(() => lazyCopy.Vector.BinarySearchByFlatBufferKey("AAA"));
+                Assert.Throws<InvalidOperationException>(() => lazyCopy.Vector.BinarySearchByFlatBufferKey(3));
+                Assert.Throws<ArgumentNullException>(() => lazyCopy.Vector.BinarySearchByFlatBufferKey((string)null));
+            }
+
+            // Two keys / one key errors
+            {
+                // Can't have more than one key on something we serialize as that trips up type model validation.
+                IReadOnlyList<TableWithTwoKeys<string>> list = new List<TableWithTwoKeys<string>>
+                {
+                    new TableWithTwoKeys<string>() { Key = "a", Value = "a" },
+                    new TableWithTwoKeys<string>() { Key = "b", Value = "b" },
+                };
+
+                var ex = Assert.Throws<InvalidOperationException>(() => list.BinarySearchByFlatBufferKey("foo"));
+            }
+            {
+                var parsed = SerializerLookup[FlatBufferDeserializationOption.Lazy].Parse<RootTable<IReadOnlyList<TableWithNoKey<string>>>>(data);
+                var ex = Assert.Throws<InvalidOperationException>(() => parsed.Vector.BinarySearchByFlatBufferKey("foo"));
             }
         }
+    }
 
-        public class SortedVector_Bool : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorTest<bool>(rng => rng.Next() % 2 == 0, Comparer<bool>.Default);
-        }
+    public class SortedVector_Bool : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorTest<bool>(rng => rng.Next() % 2 == 0, Comparer<bool>.Default);
+    }
 
-        public class SortedVector_Byte : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<byte>();
-        }
+    public class SortedVector_Byte : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<byte>();
+    }
 
-        public class SortedVector_SByte : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<sbyte>();
-        }
+    public class SortedVector_SByte : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<sbyte>();
+    }
 
-        public class SortedVector_UShort : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<ushort>();
-        }
+    public class SortedVector_UShort : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<ushort>();
+    }
 
-        public class SortedVector_Short : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<short>();
-        }
+    public class SortedVector_Short : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<short>();
+    }
 
-        public class SortedVector_Uint : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<uint>();
-        }
+    public class SortedVector_Uint : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<uint>();
+    }
 
-        public class SortedVector_Int : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<int>();
-        }
+    public class SortedVector_Int : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<int>();
+    }
 
-        public class SortedVector_Ulong : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<ulong>();
-        }
-        public class SortedVector_Long : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<long>();
-        }
+    public class SortedVector_Ulong : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<ulong>();
+    }
 
-        public class SortedVector_Double : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<double>();
-        }
+    public class SortedVector_Long : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<long>();
+    }
 
-        public class SortedVector_Float : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() => this.SortedVectorStructTest<float>();
-        }
+    public class SortedVector_Double : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<double>();
+    }
 
-        public class SortedVector_String_Base64 : VectorSerializationTests
+    public class SortedVector_Float : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorStructTest<float>();
+    }
+
+    public class SortedVector_String_Base64 : VectorSerializationTests
+    {
+        [Fact]
+        public void Test() => this.SortedVectorTest<string>(
+            rng =>
+            {
+                int length = rng.Next(0, 2048);
+                byte[] data = new byte[length];
+                rng.NextBytes(data);
+                return Convert.ToBase64String(data);
+            },
+            new Utf8StringComparer());
+    }
+
+    public class SortedVector_String_RandomChars : VectorSerializationTests
+    {
+        [Fact]
+        public void Test()
         {
-            [Fact]
-            public void Test() => this.SortedVectorTest<string>(
+            int i = 0;
+            StringBuilder s = new StringBuilder();
+
+            this.SortedVectorTest<string>(
                 rng =>
                 {
-                    int length = rng.Next(0, 2048);
-                    byte[] data = new byte[length];
-                    rng.NextBytes(data);
-                    return Convert.ToBase64String(data);
+                    s.Clear();
+                    for (int j = 0; j < Math.Min(i, 100); ++j)
+                    {
+                        s.Append("a");
+                    }
+
+                    ++i;
+                    return s.ToString();
                 },
                 new Utf8StringComparer());
         }
+    }
 
-        public class SortedVector_String_RandomChars : VectorSerializationTests
+    public class SortedVector_String_Empty : VectorSerializationTests
+    {
+        [Fact]
+        public void Test()
         {
-            [Fact]
-            public void Test()
-            {
-                int i = 0;
-                StringBuilder s = new StringBuilder();
-
-                this.SortedVectorTest<string>(
-                    rng =>
-                    {
-                        for (int j = 0; j < Math.Min(i, 100); ++j)
-                        {
-                            s.Append("a");
-                        }
-
-                        ++i;
-                        string val = s.ToString();
-                        s.Clear();
-                        return val;
-                    },
-                    new Utf8StringComparer());
-            }
-        }
-
-        public class SortedVector_String_Empty : VectorSerializationTests
-        {
-            [Fact]
-            public void Test() =>
-                this.SortedVectorTest<string>(
-                    rng =>
-                    {
-                        int length = rng.Next(0, 30);
-                        string s = "";
-                        for (int i = 0; i < length; ++i)
-                        {
-                            // pick unicode characters in the basic multilingual plane.
-                            s += (char)rng.Next(0x0, 0xD7FF);
-                        }
-
-                        return s;
-                    },
-                    new Utf8StringComparer());
-        }
-
-        public class IndexedVectorTests
-        {
-            [Fact]
-            public void IndexedVector_Simple()
-            {
-                var table = new RootTableSorted<IIndexedVector<string, TableWithKey<string>>>
+            StringBuilder sb = new();
+            this.SortedVectorTest<string>(
+                rng =>
                 {
-                    Vector = new IndexedVector<string, TableWithKey<string>>
+                    sb.Clear();
+                    int length = rng.Next(0, 2048);
+                    for (int i = 0; i < length; ++i)
                     {
-                        { new TableWithKey<string> { Key = "a", Value = "AAA" } },
-                        { new TableWithKey<string> { Key = "b", Value = "BBB" } },
-                        { new TableWithKey<string> { Key = "c", Value = "CCC" } },
+                        // pick unicode characters in the basic multilingual plane.
+                        sb.Append((char)rng.Next(0x0, 0xD7FF));
                     }
-                };
 
-                var serializer = new FlatBufferSerializer(FlatBufferDeserializationOption.Lazy);
+                    return sb.ToString();
+                },
+                new Utf8StringComparer());
+        }
+    }
 
-                byte[] data = new byte[1024 * 1024];
-                serializer.Serialize(table, data);
+    public class IndexedVectorTests
+    {
+        [Fact]
+        public void IndexedVector_Simple()
+        {
+            var table = new RootTableSorted<IIndexedVector<string, TableWithKey<string>>>
+            {
+                Vector = new IndexedVector<string, TableWithKey<string>>
+                {
+                    { new TableWithKey<string> { Key = "a", Value = "AAA" } },
+                    { new TableWithKey<string> { Key = "b", Value = "BBB" } },
+                    { new TableWithKey<string> { Key = "c", Value = "CCC" } },
+                }
+            };
 
-                var parsed = serializer.Parse<RootTableSorted<IIndexedVector<string, TableWithKey<string>>>>(data);
+            var serializer = new FlatBufferSerializer(FlatBufferDeserializationOption.Lazy);
 
-                Assert.Equal("AAA", parsed.Vector["a"].Value);
-                Assert.Equal("BBB", parsed.Vector["b"].Value);
-                Assert.Equal("CCC", parsed.Vector["c"].Value);
+            byte[] data = new byte[1024 * 1024];
+            serializer.Serialize(table, data);
 
-                Assert.True(parsed.Vector.TryGetValue("a", out var value) && value.Value == "AAA");
-                Assert.True(parsed.Vector.TryGetValue("b", out value) && value.Value == "BBB");
-                Assert.True(parsed.Vector.TryGetValue("c", out value) && value.Value == "CCC");
+            var parsed = serializer.Parse<RootTableSorted<IIndexedVector<string, TableWithKey<string>>>>(data);
+
+            Assert.Equal("AAA", parsed.Vector["a"].Value);
+            Assert.Equal("BBB", parsed.Vector["b"].Value);
+            Assert.Equal("CCC", parsed.Vector["c"].Value);
+
+            Assert.True(parsed.Vector.TryGetValue("a", out var value) && value.Value == "AAA");
+            Assert.True(parsed.Vector.TryGetValue("b", out value) && value.Value == "BBB");
+            Assert.True(parsed.Vector.TryGetValue("c", out value) && value.Value == "CCC");
+        }
+
+        [Fact]
+        public void IndexedVector_RandomString()
+        {
+            var table = new RootTable<IIndexedVector<string, TableWithKey<string>>>
+            {
+                Vector = new IndexedVector<string, TableWithKey<string>>()
+            };
+
+            List<string> keys = new List<string>();
+            for (int i = 0; i < 1000; ++i)
+            {
+                string key = Guid.NewGuid().ToString();
+                keys.Add(key);
+
+                table.Vector.AddOrReplace(new TableWithKey<string> { Key = key, Value = Guid.NewGuid().ToString() });
             }
 
-            [Fact]
-            public void IndexedVector_RandomString()
+            byte[] data = new byte[10 * 1024 * 1024];
+            var serializer = new FlatBufferSerializer(FlatBufferDeserializationOption.Lazy);
+            serializer.Compile<RootTable<IIndexedVector<string, TableWithKey<string>>>>();
+            int bytesWritten = serializer.Serialize(table, data);
+
+            var parsed = serializer.Parse<RootTable<IIndexedVector<string, TableWithKey<string>>>>(data);
+
+            foreach (var key in keys)
             {
-                var table = new RootTable<IIndexedVector<string, TableWithKey<string>>>
+                Assert.Equal(table.Vector[key].Value, parsed.Vector[key].Value);
+            }
+        }
+
+        [Fact]
+        public void IndexedVector_RandomByte() => IndexedVectorScalarTest<byte>();
+
+        [Fact]
+        public void IndexedVector_RandomSByte() => IndexedVectorScalarTest<sbyte>();
+
+        [Fact]
+        public void IndexedVector_RandomUShort() => IndexedVectorScalarTest<ushort>();
+
+        [Fact]
+        public void IndexedVector_RandomShort() => IndexedVectorScalarTest<short>();
+
+        [Fact]
+        public void IndexedVector_RandomUInt() => IndexedVectorScalarTest<uint>();
+
+        [Fact]
+        public void IndexedVector_RandomInt() => IndexedVectorScalarTest<int>();
+
+        [Fact]
+        public void IndexedVector_RandomULong() => IndexedVectorScalarTest<ulong>();
+
+        [Fact]
+        public void IndexedVector_RandomLong() => IndexedVectorScalarTest<long>();
+
+        private void IndexedVectorScalarTest<T>() where T : struct
+        {
+            foreach (FlatBufferDeserializationOption option in Enum.GetValues(typeof(FlatBufferDeserializationOption)))
+            {
+                var table = new RootTable<IIndexedVector<T, TableWithKey<T>>>
                 {
-                    Vector = new IndexedVector<string, TableWithKey<string>>()
+                    Vector = new IndexedVector<T, TableWithKey<T>>()
                 };
 
-                List<string> keys = new List<string>();
+                Random r = new Random();
+                byte[] keyBuffer = new byte[8];
+                List<T> keys = new List<T>();
                 for (int i = 0; i < 1000; ++i)
                 {
-                    string key = Guid.NewGuid().ToString();
+                    r.NextBytes(keyBuffer);
+                    T key = MemoryMarshal.Cast<byte, T>(keyBuffer)[0];
                     keys.Add(key);
-
-                    table.Vector.AddOrReplace(new TableWithKey<string> { Key = key, Value = Guid.NewGuid().ToString() });
+                    table.Vector.AddOrReplace(new TableWithKey<T> { Key = key, Value = Guid.NewGuid().ToString() });
                 }
 
-                byte[] data = new byte[10 * 1024 * 1024];
-                var serializer = new FlatBufferSerializer(FlatBufferDeserializationOption.Lazy);
-                serializer.Compile<RootTable<IIndexedVector<string, TableWithKey<string>>>>();
+                byte[] data = new byte[1024 * 1024];
+                var serializer = new FlatBufferSerializer(option);
                 int bytesWritten = serializer.Serialize(table, data);
 
-                var parsed = serializer.Parse<RootTable<IIndexedVector<string, TableWithKey<string>>>>(data);
+                var parsed = serializer.Parse<RootTable<IIndexedVector<T, TableWithKey<T>>>>(data);
 
                 foreach (var key in keys)
                 {
                     Assert.Equal(table.Vector[key].Value, parsed.Vector[key].Value);
                 }
+
+                // verify sorted and that we can read it when it's from a normal vector.
+                var parsedList = serializer.Parse<RootTable<IList<TableWithKey<T>>>>(data);
+                Assert.Equal(parsed.Vector.Count, parsedList.Vector.Count);
+                var previous = parsedList.Vector[0];
+                for (int i = 1; i < parsedList.Vector.Count; ++i)
+                {
+                    var item = parsedList.Vector[i];
+                    Assert.True(Comparer<T>.Default.Compare(previous.Key, item.Key) <= 0);
+
+                    Assert.True(parsed.Vector.TryGetValue(item.Key, out var fromDict));
+                    Assert.Equal(item.Key, fromDict.Key);
+                    Assert.Equal(item.Value, fromDict.Value);
+
+                    previous = item;
+                }
+            }
+        }
+    }
+
+    protected void SortedVectorStructTest<TKey>() where TKey : struct
+    {
+        this.SortedVectorTest(
+            rng =>
+            {
+                byte[] data = new byte[8];
+                rng.NextBytes(data);
+                TKey value = MemoryMarshal.Cast<byte, TKey>(data.AsSpan())[0];
+                return value;
+            },
+            Comparer<TKey>.Default);
+    }
+
+    protected void SortedVectorTest<TKey>(
+        Func<Random, TKey> createValue,
+        IComparer<TKey> comparer)
+    {
+        Random rng = new Random();
+        foreach (int length in Enumerable.Range(0, 20).Concat(Enumerable.Range(1, 5).Select(x => x * 100)))
+        {
+            TableWithKey<TKey>[] values = new TableWithKey<TKey>[length];
+            for (int i = 0; i < values.Length; ++i)
+            {
+                values[i] = new TableWithKey<TKey> { Key = createValue(rng), Value = i.ToString() };
             }
 
-            [Fact]
-            public void IndexedVector_RandomByte() => IndexedVectorScalarTest<byte>();
+            this.SortedVectorTest(values, comparer);
+        }
+    }
 
-            [Fact]
-            public void IndexedVector_RandomSByte() => IndexedVectorScalarTest<sbyte>();
+    protected void SortedVectorTest<TKey>(
+        TableWithKey<TKey>[] values,
+        IComparer<TKey> comparer)
+    {
+        RootTableSorted<TableWithKey<TKey>[]> root = new RootTableSorted<TableWithKey<TKey>[]>
+        {
+            Vector = values
+        };
 
-            [Fact]
-            public void IndexedVector_RandomUShort() => IndexedVectorScalarTest<ushort>();
+        byte[] data = new byte[FlatBufferSerializer.Default.GetMaxSize(root)];
+        FlatBufferSerializer.Default.Serialize(root, data);
 
-            [Fact]
-            public void IndexedVector_RandomShort() => IndexedVectorScalarTest<short>();
+        void RunTest<TVector>(
+            FlatBufferSerializer serializer,
+            Func<TVector, int> getLength,
+            Func<TVector, int, TableWithKey<TKey>> indexer,
+            Func<TVector, TKey, TableWithKey<TKey>?> find)
+        {
+            var parsed = serializer.Parse<RootTableSorted<TVector>>(data);
+            var vector = parsed.Vector;
+            int length = getLength(vector);
 
-            [Fact]
-            public void IndexedVector_RandomUInt() => IndexedVectorScalarTest<uint>();
+            Assert.Equal(root.Vector.Length, length);
 
-            [Fact]
-            public void IndexedVector_RandomInt() => IndexedVectorScalarTest<int>();
-
-            [Fact]
-            public void IndexedVector_RandomULong() => IndexedVectorScalarTest<ulong>();
-
-            [Fact]
-            public void IndexedVector_RandomLong() => IndexedVectorScalarTest<long>();
-
-            private void IndexedVectorScalarTest<T>() where T : struct
+            if (length > 0)
             {
-                foreach (FlatBufferDeserializationOption option in Enum.GetValues(typeof(FlatBufferDeserializationOption)))
+                TableWithKey<TKey> previous = indexer(vector, 0);
+                for (int i = 0; i < length; ++i)
                 {
-                    var table = new RootTable<IIndexedVector<T, TableWithKey<T>>>
-                    {
-                        Vector = new IndexedVector<T, TableWithKey<T>>()
-                    };
+                    var item = indexer(vector, i);
+                    Assert.True(comparer.Compare(previous.Key, item.Key) <= 0);
+                    previous = item;
+                }
 
-                    Random r = new Random();
-                    byte[] keyBuffer = new byte[8];
-                    List<T> keys = new List<T>();
-                    for (int i = 0; i < 1000; ++i)
+                foreach (var originalItem in root.Vector)
+                {
+                    var item = find(vector, originalItem.Key);
+                    Assert.NotNull(item);
+
+                    if (originalItem.Key.ToString() != item.Key.ToString())
                     {
-                        r.NextBytes(keyBuffer);
-                        T key = MemoryMarshal.Cast<byte, T>(keyBuffer)[0];
-                        keys.Add(key);
-                        table.Vector.AddOrReplace(new TableWithKey<T> { Key = key, Value = Guid.NewGuid().ToString() });
                     }
 
-                    byte[] data = new byte[1024 * 1024];
-                    var serializer = new FlatBufferSerializer(option);
-                    int bytesWritten = serializer.Serialize(table, data);
-
-                    var parsed = serializer.Parse<RootTable<IIndexedVector<T, TableWithKey<T>>>>(data);
-
-                    foreach (var key in keys)
-                    {
-                        Assert.Equal(table.Vector[key].Value, parsed.Vector[key].Value);
-                    }
-
-                    // verify sorted and that we can read it when it's from a normal vector.
-                    var parsedList = serializer.Parse<RootTable<IList<TableWithKey<T>>>>(data);
-                    Assert.Equal(parsed.Vector.Count, parsedList.Vector.Count);
-                    var previous = parsedList.Vector[0];
-                    for (int i = 1; i < parsedList.Vector.Count; ++i)
-                    {
-                        var item = parsedList.Vector[i];
-                        Assert.True(Comparer<T>.Default.Compare(previous.Key, item.Key) <= 0);
-
-                        Assert.True(parsed.Vector.TryGetValue(item.Key, out var fromDict));
-                        Assert.Equal(item.Key, fromDict.Key);
-                        Assert.Equal(item.Value, fromDict.Value);
-
-                        previous = item;
-                    }
+                    Assert.Equal(originalItem.Key.ToString(), item.Key.ToString());
                 }
             }
         }
 
-        protected void SortedVectorStructTest<TKey>() where TKey : struct
+        foreach (var kvp in SerializerLookup)
         {
-            this.SortedVectorTest(
-                rng =>
-                {
-                    byte[] data = new byte[8];
-                    rng.NextBytes(data);
-                    TKey value = MemoryMarshal.Cast<byte, TKey>(data.AsSpan())[0];
-                    return value;
-                },
-                Comparer<TKey>.Default);
-        }
-
-        protected void SortedVectorTest<TKey>(
-            Func<Random, TKey> createValue,
-            IComparer<TKey> comparer)
-        {
-            Random rng = new Random();
-            foreach (int length in Enumerable.Range(0, 20).Concat(Enumerable.Range(1, 5).Select(x => x * 100)))
+            // Arrays only supported in greedy mode.
+            if (kvp.Key == FlatBufferDeserializationOption.Greedy
+             || kvp.Key == FlatBufferDeserializationOption.GreedyMutable)
             {
-                TableWithKey<TKey>[] values = new TableWithKey<TKey>[length];
-                for (int i = 0; i < values.Length; ++i)
-                {
-                    values[i] = new TableWithKey<TKey> { Key = createValue(rng), Value = i.ToString() };
-                }
-
-                this.SortedVectorTest(values, comparer);
+                RunTest<TableWithKey<TKey>[]>(kvp.Value, x => x.Length, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
             }
-        }
 
-        protected void SortedVectorTest<TKey>(
-            TableWithKey<TKey>[] values,
-            IComparer<TKey> comparer)
+            RunTest<IList<TableWithKey<TKey>>>(kvp.Value, x => x.Count, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
+            RunTest<IReadOnlyList<TableWithKey<TKey>>>(kvp.Value, x => x.Count, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
+        }
+    }
+
+    public class VectorOfUnionTests
+    {
+        [Fact]
+        public void VectorOfUnion_List() => this.VectorOfUnionTest<RootTable<IList<FlatBufferUnion<string, Struct, TableWithKey<int>>>>>(
+            (l, v) => v.Vector = l.ToList());
+
+        [Fact]
+        public void VectorOfUnion_ReadOnlyList() => this.VectorOfUnionTest<RootTable<IReadOnlyList<FlatBufferUnion<string, Struct, TableWithKey<int>>>>>(
+            (l, v) => v.Vector = l.ToList());
+
+        [Fact]
+        public void VectorOfUnion_Array() => this.VectorOfUnionTest<RootTable<FlatBufferUnion<string, Struct, TableWithKey<int>>[]>>(
+            (l, v) => v.Vector = l);
+
+        private void VectorOfUnionTest<V>(Action<FlatBufferUnion<string, Struct, TableWithKey<int>>[], V> setValue)
+            where V : class, new()
         {
-            RootTableSorted<TableWithKey<TKey>[]> root = new RootTableSorted<TableWithKey<TKey>[]>
+            var items = new[]
             {
-                Vector = values
+                new FlatBufferUnion<string, Struct, TableWithKey<int>>("foo"),
+                new FlatBufferUnion<string, Struct, TableWithKey<int>>(new Struct { Integer = 3 }),
+                new FlatBufferUnion<string, Struct, TableWithKey<int>>(new TableWithKey<int> { Key = 1 }),
             };
 
-            byte[] data = new byte[1024 * 1024];
-            FlatBufferSerializer.Default.Serialize(root, data);
+            V value = new V();
+            setValue(items, value);
 
-            void RunTest<TVector>(
-                FlatBufferSerializer serializer,
-                Func<TVector, int> getLength,
-                Func<TVector, int, TableWithKey<TKey>> indexer,
-                Func<TVector, TKey, TableWithKey<TKey>?> find)
+            byte[] expectedData =
             {
-                var parsed = serializer.Parse<RootTableSorted<TVector>>(data);
-                var vector = parsed.Vector;
-                int length = getLength(vector);
+                4, 0, 0, 0,
+                244, 255, 255, 255,
+                16, 0, 0, 0, // uoffset to discriminator vector
+                20, 0, 0, 0, // uoffset to offset vector
+                8, 0,        // vtable
+                12, 0,
+                4, 0,
+                8, 0,
+                3, 0, 0, 0, // discriminator vector length
+                1, 2, 3, 0, // values + 1 byte padding
+                3, 0, 0, 0, // offset vector length
+                12, 0, 0, 0, // value 0
+                16, 0, 0, 0, // value 1
+                16, 0, 0, 0, // value 2
+                3, 0, 0, 0,  // string length
+                102, 111, 111, 0, // foo + null terminator
+                3, 0, 0, 0,       // struct value ('3')
+                248, 255, 255, 255, // table vtable offset
+                1, 0, 0, 0,         // value of 'key'
+                8, 0,               // table vtable start
+                8, 0,
+                0, 0,
+                4, 0,
+            };
 
-                Assert.Equal(root.Vector.Length, length);
+            byte[] data = new byte[1024];
+            int written = FlatBufferSerializer.Default.Serialize(value, data);
+            data = data.AsSpan().Slice(0, written).ToArray();
 
-                if (length > 0)
-                {
-                    TableWithKey<TKey> previous = indexer(vector, 0);
-                    for (int i = 0; i < length; ++i)
-                    {
-                        var item = indexer(vector, i);
-                        Assert.True(comparer.Compare(previous.Key, item.Key) <= 0);
-                        previous = item;
-                    }
-
-                    foreach (var originalItem in root.Vector)
-                    {
-                        var item = find(vector, originalItem.Key);
-                        Assert.NotNull(item);
-
-                        if (originalItem.Key.ToString() != item.Key.ToString())
-                        {
-                        }
-
-                        Assert.Equal(originalItem.Key.ToString(), item.Key.ToString());
-                    }
-                }
-            }
-
-            foreach (var kvp in SerializerLookup)
-            {
-                // Arrays only supported in greedy mode.
-                if (kvp.Key == FlatBufferDeserializationOption.Greedy
-                 || kvp.Key == FlatBufferDeserializationOption.GreedyMutable)
-                {
-                    RunTest<TableWithKey<TKey>[]>(kvp.Value, x => x.Length, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
-                }
-
-                RunTest<IList<TableWithKey<TKey>>>(kvp.Value, x => x.Count, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
-                RunTest<IReadOnlyList<TableWithKey<TKey>>>(kvp.Value, x => x.Count, (x, i) => x[i], (x, k) => x.BinarySearchByFlatBufferKey(k));
-            }
+            Assert.True(data.SequenceEqual(expectedData));
         }
+    }
 
-        public class VectorOfUnionTests
-        {
-            [Fact]
-            public void VectorOfUnion_List() => this.VectorOfUnionTest<RootTable<IList<FlatBufferUnion<string, Struct, TableWithKey<int>>>>>(
-                (l, v) => v.Vector = l.ToList());
+    [FlatBufferTable]
+    public class RootTable<TVector>
+    {
+        [FlatBufferItem(0)]
+        public virtual TVector? Vector { get; set; }
+    }
 
-            [Fact]
-            public void VectorOfUnion_ReadOnlyList() => this.VectorOfUnionTest<RootTable<IReadOnlyList<FlatBufferUnion<string, Struct, TableWithKey<int>>>>>(
-                (l, v) => v.Vector = l.ToList());
+    [FlatBufferTable]
+    public class RootTableSorted<TVector>
+    {
+        [FlatBufferItem(0, SortedVector = true)]
+        public virtual TVector? Vector { get; set; }
+    }
 
-            [Fact]
-            public void VectorOfUnion_Array() => this.VectorOfUnionTest<RootTable<FlatBufferUnion<string, Struct, TableWithKey<int>>[]>>(
-                (l, v) => v.Vector = l);
+    [FlatBufferTable]
+    public class TableWithKey<TKey>
+    {
+        [FlatBufferItem(0)]
+        public virtual string? Value { get; set; }
 
-            private void VectorOfUnionTest<V>(Action<FlatBufferUnion<string, Struct, TableWithKey<int>>[], V> setValue)
-                where V : class, new()
-            {
-                var items = new[]
-                {
-                    new FlatBufferUnion<string, Struct, TableWithKey<int>>("foo"),
-                    new FlatBufferUnion<string, Struct, TableWithKey<int>>(new Struct { Integer = 3 }),
-                    new FlatBufferUnion<string, Struct, TableWithKey<int>>(new TableWithKey<int> { Key = 1 }),
-                };
+        [FlatBufferItem(1, Key = true)]
+        public virtual TKey? Key { get; set; }
+    }
 
-                V value = new V();
-                setValue(items, value);
+    [FlatBufferTable]
+    public class TableWithNoKey<TKey>
+    {
+        [FlatBufferItem(0)]
+        public virtual string? Value { get; set; }
 
-                byte[] expectedData =
-                {
-                    4, 0, 0, 0,
-                    244, 255, 255, 255,
-                    16, 0, 0, 0, // uoffset to discriminator vector
-                    20, 0, 0, 0, // uoffset to offset vector
-                    8, 0,        // vtable
-                    12, 0,
-                    4, 0,
-                    8, 0,
-                    3, 0, 0, 0, // discriminator vector length
-                    1, 2, 3, 0, // values + 1 byte padding
-                    3, 0, 0, 0, // offset vector length
-                    12, 0, 0, 0, // value 0
-                    16, 0, 0, 0, // value 1
-                    16, 0, 0, 0, // value 2
-                    3, 0, 0, 0,  // string length
-                    102, 111, 111, 0, // foo + null terminator
-                    3, 0, 0, 0,       // struct value ('3')
-                    248, 255, 255, 255, // table vtable offset
-                    1, 0, 0, 0,         // value of 'key'
-                    8, 0,               // table vtable start
-                    8, 0,
-                    0, 0,
-                    4, 0,
-                };
+        [FlatBufferItem(1)]
+        public virtual TKey? Key { get; set; }
+    }
 
-                byte[] data = new byte[1024];
-                int written = FlatBufferSerializer.Default.Serialize(value, data);
-                data = data.AsSpan().Slice(0, written).ToArray();
+    [FlatBufferTable]
+    public class TableWithTwoKeys<TKey>
+    {
+        [FlatBufferItem(0, Key = true)]
+        public virtual string? Value { get; set; }
 
-                Assert.True(data.SequenceEqual(expectedData));
-            }
-        }
+        [FlatBufferItem(1, Key = true)]
+        public virtual TKey? Key { get; set; }
+    }
 
-        [FlatBufferTable]
-        public class RootTable<TVector>
-        {
-            [FlatBufferItem(0)]
-            public virtual TVector? Vector { get; set; }
-        }
+    [FlatBufferTable]
+    public class RootTable2<TVector>
+    {
+        [FlatBufferItem(0, DefaultValue = (byte)201)]
+        public virtual byte AlignmentImp { get; set; }
 
-        [FlatBufferTable]
-        public class RootTableSorted<TVector>
-        {
-            [FlatBufferItem(0, SortedVector = true)]
-            public virtual TVector? Vector { get; set; }
-        }
+        [FlatBufferItem(1)]
+        public virtual TVector? Vector { get; set; }
+    }
 
-        [FlatBufferTable]
-        public class TableWithKey<TKey>
-        {
-            [FlatBufferItem(0)]
-            public virtual string? Value { get; set; }
+    [FlatBufferStruct]
+    public class Struct
+    {
+        [FlatBufferItem(0)]
+        public virtual int Integer { get; set; }
+    }
 
-            [FlatBufferItem(1, Key = true)]
-            public virtual TKey? Key { get; set; }
-        }
+    [FlatBufferStruct]
+    public class NineByteStruct
+    {
+        [FlatBufferItem(0)]
+        public virtual long Long { get; set; }
 
-        [FlatBufferTable]
-        public class RootTable2<TVector>
-        {
-            [FlatBufferItem(0, DefaultValue = (byte)201)]
-            public virtual byte AlignmentImp { get; set; }
+        [FlatBufferItem(1)]
+        public virtual byte Byte { get; set; }
+    }
 
-            [FlatBufferItem(1)]
-            public virtual TVector? Vector { get; set; }
-        }
+    [FlatBufferStruct, StructLayout(LayoutKind.Explicit, Size = 9)]
+    public struct ValueNineByteStruct
+    {
+        [FieldOffset(0)] public long Long;
 
-        [FlatBufferStruct]
-        public class Struct
-        {
-            [FlatBufferItem(0)]
-            public virtual int Integer { get; set; }
-        }
-
-        [FlatBufferStruct]
-        public class NineByteStruct
-        {
-            [FlatBufferItem(0)]
-            public virtual long Long { get; set; }
-
-            [FlatBufferItem(1)]
-            public virtual byte Byte { get; set; }
-        }
-
-        [FlatBufferStruct, StructLayout(LayoutKind.Explicit, Size = 9)]
-        public struct ValueNineByteStruct
-        {
-            [FieldOffset(0)] public long Long;
-
-            [FieldOffset(8)] public byte Byte;
-        }
+        [FieldOffset(8)] public byte Byte;
     }
 }


### PR DESCRIPTION
Optimize memory allocations during binary search:

- No more delegate allocations (structs instead!)
- In non-greedy modes, add a fast-path binary search that avoids the `byte` -> `string` -> `byte` indirection that is necessary if going through the deserialized type.
- Make use of `ArrayPool<byte>.Shared` to avoid allocating temporary buffers

Results:
```
original
|           Method |        Option | Length | TravCount |     Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Allocated |
|----------------- |-------------- |------- |---------- |---------:|----------:|----------:|----------:|---------:|-------------:|
|        Serialize |          Lazy |  10000 |         1 | 1.603 ms | 0.0226 ms | 0.0269 ms |         - |        - |         90 B |
| ParseAndTraverse |          Lazy |  10000 |         1 | 8.921 ms | 0.2489 ms | 0.2963 ms | 1328.1250 |        - | 22,442,928 B |
|        Serialize | GreedyMutable |  10000 |         1 | 1.585 ms | 0.0167 ms | 0.0199 ms |         - |        - |         90 B |
| ParseAndTraverse | GreedyMutable |  10000 |         1 | 4.736 ms | 0.0955 ms | 0.1137 ms |  296.8750 | 125.0000 |  5,040,144 B |
```
```
with fixes
|           Method |        Option | Length | TravCount |     Mean |     Error |    StdDev |   Gen 0 |   Gen 1 |   Allocated |
|----------------- |-------------- |------- |---------- |---------:|----------:|----------:|--------:|--------:|------------:|
|        Serialize |          Lazy |  10000 |         1 | 1.459 ms | 0.0154 ms | 0.0040 ms |       - |       - |        90 B |
| ParseAndTraverse |          Lazy |  10000 |         1 | 3.967 ms | 0.1170 ms | 0.0181 ms | 39.0625 |       - |   720,107 B |
|        Serialize | GreedyMutable |  10000 |         1 | 1.377 ms | 0.0014 ms | 0.0004 ms |       - |       - |        90 B |
| ParseAndTraverse | GreedyMutable |  10000 |         1 | 4.849 ms | 0.0348 ms | 0.0054 ms | 78.1250 | 31.2500 | 1,360,147 B |
```