### PR TITLE
Updated Samples to demonstrate the new IncludePath feature

### DIFF
--- a/samples/Example07-Includes/Shared/C.fbs
+++ b/samples/Example07-Includes/Shared/C.fbs
@@ -14,20 +14,8 @@
  * limitations under the License.
  */
 
-include "Subdirectory/B.fbs";
-include "Shared/C.fbs";
-
 namespace Samples.IncludesExample;
 
-table TableFromA {
-   NestedTableB:TableFromB;
-   NestedTableC:TableFromC;
-   NestedEnum:EnumFromB;
-   NestedStruct1:StructFromA;
-   NestedStruct2:StructFromB;
-}
-
-struct StructFromA {
-  NestedStruct:StructFromB;
-  Value:int;
+table TableFromC {
+    String:string;
 }

--- a/samples/Example07-Includes/Subdirectory/B.fbs
+++ b/samples/Example07-Includes/Subdirectory/B.fbs
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+include "Shared/C.fbs";
+
 namespace Samples.IncludesExample;
 
 enum EnumFromB : ubyte { One, Two, Three }
 
 table TableFromB {
+    NestedTableC:TableFromC;
     String:string;
 }
 

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -13,9 +13,9 @@
     <FlatSharpSchema Include="Example04-IOOptions\IOOptionsExample.fbs" />
     <FlatSharpSchema Include="Example05-gRPC\GrpcExample.fbs" />
     <FlatSharpSchema Include="Example06-CopyConstructors\CopyConstructorsExample.fbs" />
-    <FlatSharpSchema Include="Example07-Includes\A.fbs" />
-    <FlatSharpSchema Include="Example07-Includes\Subdirectory\B.fbs" />
-    <FlatSharpSchema Include="Example07-Includes\IncludesExample.fbs" />
+    <FlatSharpSchema Include="Example07-Includes\**\*.fbs">
+      <IncludePath>Example07-Includes</IncludePath>
+    </FlatSharpSchema>
     <FlatSharpSchema Include="Example08-SortedVectors\SortedVectors.fbs" />
     <FlatSharpSchema Include="Example09-Unions\Unions.fbs" />
     <FlatSharpSchema Include="Example10-SharedStrings\SharedStrings.fbs" />
@@ -26,12 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FlatSharp" Version="6.0.5" />
-    <PackageReference Include="FlatSharp.Compiler" Version="6.0.5">
+    <PackageReference Include="FlatSharp" Version="6.1.0" />
+    <PackageReference Include="FlatSharp.Compiler" Version="6.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FlatSharp.Runtime" Version="6.0.5" />
+    <PackageReference Include="FlatSharp.Runtime" Version="6.1.0" />
     <PackageReference Include="Grpc" Version="2.38.1" />
   </ItemGroup>
 


### PR DESCRIPTION
I have updated the sample projects to the next pending release, 6.1.0, and updated the **Example07-Includes** sample to demonstrate the new IncludePath feature based on #266.

Also note that **Example10-SharedStrings\SharedStringsExample.cs** is not currently compiling due to other changes.