### PR TITLE
Add fs_preserveFieldCasing attribute

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -23,6 +23,7 @@ using System.Threading;
 
 using CommandLine;
 using FlatSharp.CodeGen;
+using FlatSharp.Compiler.SchemaModel;
 using FlatSharp.TypeModel;
 
 namespace FlatSharp.Compiler;
@@ -496,9 +497,19 @@ public class FlatSharpCompiler
         {
             foreach (Schema.FlatBufferObject item in schema.Objects)
             {
+                bool? preserveFieldCasingParent = item.Attributes != null ? new FlatSharpAttributes(item.Attributes).PreserveFieldCasing : default;
                 foreach (Schema.Field field in item.Fields)
                 {
-                    field.Name = NormalizeFieldName(field.Name);
+                    bool? preserveFieldCasing = field.Attributes != null ? preserveFieldCasing = new FlatSharpAttributes(field.Attributes).PreserveFieldCasing : default;
+
+                    var preserve = (preserveFieldCasing ?? preserveFieldCasingParent) switch
+                    {
+                        false or null => false,
+                        true => true,
+                    };
+
+                    if (!preserve)
+                        field.Name = NormalizeFieldName(field.Name);
                 }
             }
         }

--- a/src/FlatSharp.Compiler/MetadataKeys.cs
+++ b/src/FlatSharp.Compiler/MetadataKeys.cs
@@ -104,6 +104,15 @@ public static class MetadataKeys
     public const string RpcInterface = "fs_rpcInterface";
 
     /// <summary>
+    /// Controls whether field names are affected by --normalize-field-names option.
+    /// Valid On:
+    /// - Table (as a default for all fields in the table, overridden by the setting on a field)
+    /// - Struct (as a default for all fields in the struct, overridden by the setting on a field)
+    /// - Field 
+    /// </summary>
+    public const string PreserveFieldCasing = "fs_preserveFieldCasing";
+
+    /// <summary>
     /// Marks a table field as deprecated. Deprecated fields do not have their values serialized or parsed.
     /// Valid On:
     /// - Table field

--- a/src/FlatSharp.Compiler/SchemaModel/FlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/FlatSharpAttributes.cs
@@ -41,6 +41,8 @@ public class FlatSharpAttributes : IFlatSharpAttributes
 
     public bool? NonVirtual => this.TryParseBoolean(MetadataKeys.NonVirtualProperty);
 
+    public bool? PreserveFieldCasing => this.TryParseBoolean(MetadataKeys.PreserveFieldCasing);
+
     public bool? SortedVector => this.TryParseBoolean(MetadataKeys.SortedVector);
 
     public bool? SharedString => this.TryParseBoolean(MetadataKeys.SharedString);

--- a/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
@@ -29,6 +29,8 @@ public interface IFlatSharpAttributes
 
     bool? NonVirtual { get; }
 
+    bool? PreserveFieldCasing { get; }
+
     bool? RpcInterface { get; }
 
     SetterKind? SetterKind { get; }

--- a/src/FlatSharp.Compiler/SchemaModel/MutableFlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/MutableFlatSharpAttributes.cs
@@ -33,6 +33,7 @@ public class MutableFlatSharpAttributes : IFlatSharpAttributes
             this.ForceWrite = other.ForceWrite;
             this.MemoryMarshalBehavior = other.MemoryMarshalBehavior;
             this.NonVirtual = other.NonVirtual;
+            this.PreserveFieldCasing = other.PreserveFieldCasing;
             this.RpcInterface = other.RpcInterface;
             this.SetterKind = other.SetterKind;
             this.SharedString = other.SharedString;
@@ -54,6 +55,8 @@ public class MutableFlatSharpAttributes : IFlatSharpAttributes
     public MemoryMarshalBehavior? MemoryMarshalBehavior { get; set; }
 
     public bool? NonVirtual { get; set; }
+
+    public bool? PreserveFieldCasing { get; set; }
 
     public bool? RpcInterface { get; set; }
 

--- a/src/Tests/FlatSharpCompilerTests/MetadataHelpers.cs
+++ b/src/Tests/FlatSharpCompilerTests/MetadataHelpers.cs
@@ -40,6 +40,7 @@ public class MetadataHelpers
         names.Add(MetadataKeys.ForceWrite);
         names.Add(MetadataKeys.WriteThrough);
         names.Add(MetadataKeys.RpcInterface);
+        names.Add(MetadataKeys.PreserveFieldCasing);
         names.Add(string.Empty);
 
         AllAttributes = string.Join("\r\n", names.Select(x => $"attribute \"{x}\";"));


### PR DESCRIPTION
This enables overriding the behavior of --normalize-field-names at the field, struct, or table level.

This PR attempts to implements a solution for issue #305 . I did make the attribute a bit more verbose as `fs_preserveFieldCasing` but am happy to use the original suggestion of `fs_preserveCase` as well.