### PR TITLE
Add support for Unity NativeArray as vector type

### DIFF
--- a/src/FlatSharp.Compiler/CompilerOptions.cs
+++ b/src/FlatSharp.Compiler/CompilerOptions.cs
@@ -43,4 +43,7 @@ public record CompilerOptions
 
     [Option("debug", Hidden = true, Default = false)]
     public bool Debug { get; set; }
+    
+    [Option("unity-assembly-path", HelpText = "Path to assembly (e.g. UnityEngine.dll) which enables Unity support.")]
+    public string? UnityAssemblyPath { get; set; }
 }

--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -75,6 +75,12 @@ public class FlatSharpCompiler
             Console.Error.WriteLine("FlatSharp compiler: No output directory specified.");
             return -1;
         }
+        
+        if (!string.IsNullOrEmpty(options.UnityAssemblyPath) && !File.Exists(options.UnityAssemblyPath))
+        {
+            Console.Error.WriteLine("FlatSharp compiler: Unity assembly path specified does not exist.");
+            return -1;
+        }
 
         // Read existing file to see if we even need to do any work.
         const string outputFileName = "FlatSharp.generated.cs";
@@ -315,7 +321,7 @@ public class FlatSharpCompiler
     {
         try
         {
-            Assembly[] additionalRefs = additionalReferences?.ToArray() ?? Array.Empty<Assembly>();
+            Assembly[] additionalRefs = BuildAdditionalReferences(options, additionalReferences);
 
             options.InputFiles = fbsFiles.Select(x => x.FullName);
 
@@ -527,6 +533,8 @@ public class FlatSharpCompiler
             }
 
             ErrorContext.Current.ThrowIfHasErrors();
+            
+            Assembly[] additionalRefs = BuildAdditionalReferences(options);
 
             foreach (var step in steps)
             {
@@ -539,7 +547,7 @@ public class FlatSharpCompiler
                 if (step > CodeWritingPass.Initialization)
                 {
                     csharp = writer.ToString();
-                    (assembly, _, _) = RoslynSerializerGenerator.CompileAssembly(csharp, true);
+                    (assembly, _, _) = RoslynSerializerGenerator.CompileAssembly(csharp, true, additionalRefs);
                 }
 
                 writer = new CodeWriter();
@@ -552,7 +560,7 @@ public class FlatSharpCompiler
                         Options = localOptions,
                         InputHash = inputHash,
                         PreviousAssembly = assembly,
-                        TypeModelContainer = TypeModelContainer.CreateDefault(),
+                        TypeModelContainer = TypeModelContainer.CreateDefault().WithUnitySupport(localOptions.UnityAssemblyPath is not null),
                     });
 
                 ErrorContext.Current.ThrowIfHasErrors();
@@ -580,7 +588,8 @@ public class FlatSharpCompiler
         List<Func<string, string>> postProcessTransforms,
         params ISchemaMutator[] mutators)
     {
-        ISerializer<Schema.Schema> mutableSerializer = FlatBufferSerializer.Default
+        ISerializer<Schema.Schema> mutableSerializer = new FlatBufferSerializer(
+            new FlatBufferSerializerOptions(), TypeModelContainer.CreateDefault().WithUnitySupport(options.UnityAssemblyPath is not null))
             .Compile<Schema.Schema>()
             .WithSettings(s => s.UseGreedyMutableDeserialization());
 
@@ -598,5 +607,16 @@ public class FlatSharpCompiler
 
         // Immutable.
         return mutableSerializer.WithSettings(s => s.UseGreedyDeserialization()).Parse(temp);
+    }
+
+    private static Assembly[] BuildAdditionalReferences(CompilerOptions options, IEnumerable<Assembly>? additionalReferences = null)
+    {
+        var references = new List<Assembly>();
+        if (additionalReferences is not null)
+            references.AddRange(additionalReferences);
+        if (options.UnityAssemblyPath is not null)
+            references.Add(Assembly.LoadFrom(options.UnityAssemblyPath));
+        
+        return references.ToArray();
     }
 }

--- a/src/FlatSharp.Compiler/SchemaModel/PropertyFieldModel.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/PropertyFieldModel.cs
@@ -320,6 +320,7 @@ public record PropertyFieldModel
             VectorType.Memory => $"Memory<{innerType}>",
             VectorType.ReadOnlyMemory => $"ReadOnlyMemory<{innerType}>",
             VectorType.IIndexedVector => $"IIndexedVector<{keyType ?? "string"}, {innerType}>",
+            VectorType.UnityNativeArray => $"Unity.Collections.NativeArray<{innerType}>",
 
             // Unqualified ubyte vectors default to Memory.
             null => this.Field.Type.ElementType == BaseType.UByte 

--- a/src/FlatSharp.UnityPolyfills/FlatSharp.UnityPolyfills.csproj
+++ b/src/FlatSharp.UnityPolyfills/FlatSharp.UnityPolyfills.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\common.props" />
+  
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <RootNamespace>FlatSharp.UnityPolyfills</RootNamespace>
+    <Description>FlatSharp.UnityPolyfills is a utility assembly to expose the Unity API needed for FlatSharp support of UnityEngine.Collections.NativeArray.</Description>
+    <Nullable>annotations</Nullable>
+    <DefineConstants>$(DefineContants);FLATSHARP_UNITY_POLYFILLS</DefineConstants>
+    <PackageId>FlatSharp.UnityPolyfills</PackageId>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatSharp.UnityPolyfills/NativeArray.cs
+++ b/src/FlatSharp.UnityPolyfills/NativeArray.cs
@@ -1,0 +1,166 @@
+﻿/*
+ * Copyright 2022 Unity Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Unity.Collections
+{
+    public enum NativeArrayOptions
+    {
+        UninitializedMemory = 0,
+        ClearMemory = 1
+    }
+
+    public enum Allocator
+    {
+        Invalid = 0,
+        None = 1,
+        Temp = 2,
+        TempJob = 3,
+        Persistent = 4,
+    }
+
+    // for testing, we remove the 'where T : struct' constraint and enforce this in UnityNativeArrayVectorTypeModel
+    public unsafe struct NativeArray<T> : IEnumerable<T>, IEquatable<NativeArray<T>> /* where T : struct */
+    {
+        internal Memory<T> m_Buffer;
+
+        internal void* m_Data;
+        internal int m_Length;
+
+        public NativeArray(int length, Allocator allocator, NativeArrayOptions options = NativeArrayOptions.ClearMemory)
+        {
+            Allocate(length, allocator, out this);
+        }
+
+        public NativeArray(T[] array, Allocator allocator)
+        {
+            Allocate(array.Length, allocator, out this);
+            array.AsSpan().CopyTo(m_Buffer.Span);
+        }        
+        
+        public NativeArray(NativeArray<T> array, Allocator allocator)
+        {
+            Allocate(array.Length, allocator, out this);
+            array.AsSpan().CopyTo(this.AsSpan());
+        }
+
+        static void Allocate(int length, Allocator allocator, out NativeArray<T> nativeArray)
+        {
+            var backing = new T[length];
+            nativeArray = new NativeArray<T>()
+            {
+                m_Buffer = new Memory<T>(backing)
+            };
+        }
+
+        struct Enumerator : IEnumerator<T>
+        {
+            private readonly NativeArray<T> m_Array;
+            private int m_Index;
+
+            public Enumerator(NativeArray<T> nativeArray)
+            {
+                m_Array = nativeArray;
+                m_Index = -1;
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                m_Index++;
+                return m_Index < m_Array.Length;
+            }
+
+            public void Reset()
+            {
+                m_Index = -1;
+            }
+
+            // Let NativeArray indexer check for out of range.
+            public T Current => m_Array[m_Index];
+
+            object IEnumerator.Current => Current;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public bool Equals(NativeArray<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Length => m_Data != null ? m_Length : m_Buffer.Length;
+
+        public T this[int index]
+        {
+            get => AsSpan()[index];
+
+            set => AsSpan()[index] = value;
+        }
+
+        public readonly Span<T> AsSpan()
+        {
+            return m_Data != null ? new Span<T>(m_Data, m_Length) : m_Buffer.Span;
+        }
+    }
+}
+
+namespace Unity.Collections.LowLevel.Unsafe
+{
+    public static unsafe class NativeArrayUnsafeUtility
+    {
+        public static NativeArray<T> ConvertExistingDataToNativeArray<T>(void* dataPointer, int length, Allocator allocator) where T : struct
+        {
+            var newArray = new NativeArray<T>
+            {
+                m_Data = dataPointer,
+                m_Length = length,
+            };
+
+            return newArray;
+        }
+    }
+
+
+    public static unsafe class NativeArrayUnsafeUtilityEx
+    {
+        public static NativeArray<T> ConvertExistingDataToNativeArray<T>(Span<T> span, Allocator allocator) where T : struct
+        {
+            var newArray = new NativeArray<T>
+            {
+                m_Data = System.Runtime.CompilerServices.Unsafe.AsPointer(ref span.GetPinnableReference()),
+                m_Length = span.Length,
+            };
+
+            return newArray;
+        }
+    }
+}

--- a/src/FlatSharp.sln
+++ b/src/FlatSharp.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microbench.6.3.3", "Benchma
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatSharpPoolableEndToEndTests", "Tests\FlatSharpPoolableEndToEndTests\FlatSharpPoolableEndToEndTests.csproj", "{7E55A248-4BBD-48AD-B27D-A7E0E705DC89}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatSharp.UnityPolyfills", "FlatSharp.UnityPolyfills\FlatSharp.UnityPolyfills.csproj", "{E439E4AF-B948-4E6C-8791-1830619EB35B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{7E55A248-4BBD-48AD-B27D-A7E0E705DC89}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E55A248-4BBD-48AD-B27D-A7E0E705DC89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E55A248-4BBD-48AD-B27D-A7E0E705DC89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E439E4AF-B948-4E6C-8791-1830619EB35B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E439E4AF-B948-4E6C-8791-1830619EB35B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E439E4AF-B948-4E6C-8791-1830619EB35B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E439E4AF-B948-4E6C-8791-1830619EB35B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FlatSharp/FlatBufferSerializer.cs
+++ b/src/FlatSharp/FlatBufferSerializer.cs
@@ -26,6 +26,9 @@ namespace FlatSharp;
 public sealed class FlatBufferSerializer
 {
     public static FlatBufferSerializer Default { get; } = new FlatBufferSerializer(new FlatBufferSerializerOptions());
+    
+    // Test hook
+    internal static FlatBufferSerializer DefaultWithUnitySupport { get; } = new FlatBufferSerializer(new FlatBufferSerializerOptions(), TypeModelContainer.CreateDefault().WithUnitySupport(true));
 
     private readonly Dictionary<Type, object> serializerCache = new();
 

--- a/src/FlatSharp/TypeModel/TypeModelContainerExtensions.cs
+++ b/src/FlatSharp/TypeModel/TypeModelContainerExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2020 James Courtney
+ * Copyright 2022 Unity Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-namespace FlatSharp.Compiler;
+namespace FlatSharp.TypeModel;
 
-/// <summary>
-/// Enumerates supported vector types.
-/// </summary>
-public enum VectorType
+internal static class TypeModelContainerExtensions
 {
-    IList,
-    IReadOnlyList,
-    Memory,
-    ReadOnlyMemory,
-    IIndexedVector,
-    UnityNativeArray
+    public static TypeModelContainer WithUnitySupport(this TypeModelContainer container, bool enableUnitySupport)
+    {
+        if (enableUnitySupport)
+            container.RegisterProvider(new UnityTypeModelProvider());
+        return container;
+    }
 }

--- a/src/FlatSharp/TypeModel/UnityTypeModelProvider.cs
+++ b/src/FlatSharp/TypeModel/UnityTypeModelProvider.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2022 Unity Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using FlatSharp.TypeModel.Vectors;
+
+namespace FlatSharp.TypeModel;
+
+public class UnityTypeModelProvider : ITypeModelProvider
+{
+    public bool TryCreateTypeModel(TypeModelContainer container, Type type,  [NotNullWhen(true)] out ITypeModel? typeModel)
+    {
+        if (type.IsGenericType)
+        {
+            var genericDef = type.GetGenericTypeDefinition();
+            if (genericDef.Namespace == "Unity.Collections" &&  genericDef.Name == "NativeArray`1")
+            {
+                typeModel = new UnityNativeArrayVectorTypeModel(type, container);
+                return true;
+            }
+        }
+
+        typeModel = null;
+        return false;
+    }
+}

--- a/src/FlatSharp/TypeModel/Vectors/UnityNativeArrayVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/Vectors/UnityNativeArrayVectorTypeModel.cs
@@ -84,7 +84,7 @@ public class UnityNativeArrayVectorTypeModel : BaseVectorTypeModel
     public override CodeGeneratedMethod CreateSerializeMethodBody(SerializationCodeGenContext context)
     {
         var writeNativeArray = $"{context.SpanWriterVariableName}.UnsafeWriteSpan({context.SpanVariableName}, {context.ValueVariableName}.AsSpan(), {context.OffsetVariableName}, " +
-                               $"{context.SerializationContextVariableName});";
+                               $"{ItemTypeModel.PhysicalLayout[0].Alignment}, {context.SerializationContextVariableName});";
 
         return new CodeGeneratedMethod(writeNativeArray);
     }

--- a/src/FlatSharp/TypeModel/Vectors/UnityNativeArrayVectorTypeModel.cs
+++ b/src/FlatSharp/TypeModel/Vectors/UnityNativeArrayVectorTypeModel.cs
@@ -1,0 +1,101 @@
+namespace FlatSharp.TypeModel.Vectors;
+
+/// <summary>
+/// Defines a vector type model for a Unity NativeArray collection.
+/// </summary>
+public class UnityNativeArrayVectorTypeModel : BaseVectorTypeModel
+{
+    internal UnityNativeArrayVectorTypeModel(Type vectorType, TypeModelContainer provider) : base(vectorType, provider)
+    {
+    }
+
+    public override string LengthPropertyName => nameof(Memory<byte>.Length);
+
+    public override Type OnInitialize()
+    {
+        return this.ClrType.GetGenericArguments()[0];
+    }
+    
+    public override void Validate()
+    {
+        if (!this.ClrType.IsGenericType || this.ClrType.GetGenericTypeDefinition().FullName != "Unity.Collections.NativeArray`1")
+            throw new InvalidFlatBufferDefinitionException(
+                $"UnityNativeArray vectors must be of type Unity.Collections.NativeArray. Type = {this.GetCompilableTypeName()}.");
+
+        var genericArgumentType = this.ClrType.GetGenericArguments()[0];
+        if (ItemTypeModel.SchemaType != FlatBufferSchemaType.Scalar && ItemTypeModel.SchemaType != FlatBufferSchemaType.Struct)
+            throw new InvalidFlatBufferDefinitionException(
+                $"UnityNativeArray vectors only support scalar or struct generic arguments. Type = {this.GetCompilableTypeName()}.");
+        
+        if (!genericArgumentType.IsValueType)
+            throw new InvalidFlatBufferDefinitionException(
+                $"UnityNativeArray vectors only support value type generic arguments. Type = {this.GetCompilableTypeName()}.");
+        
+        if (ItemTypeModel.PhysicalLayout.Length != 1)
+            throw new InvalidFlatBufferDefinitionException(
+                $"UnityNativeArray vectors do not support the specified generic argument type. Type = {this.GetCompilableTypeName()}.");
+
+
+        base.Validate();
+    }
+
+    protected override string CreateLoop(FlatBufferSerializerOptions options, string vectorVariableName, string numberOfItemsVariableName, string expectedVariableName, string body)
+    {
+        FlatSharpInternal.Assert(false, "Not expecting to do loop get max size for memory vector");
+        throw new Exception();
+    }
+
+    public override CodeGeneratedMethod CreateParseMethodBody(ParserCodeGenContext context)
+    {
+        ValidateWriteThrough(
+            writeThroughSupported: false,
+            this,
+            context.AllFieldContexts,
+            context.Options);
+
+        if (context.Options.GreedyDeserialize)
+        {
+            string body = $@"
+                var bufferSpan = {context.InputBufferVariableName}.UnsafeReadSpan<{context.InputBufferTypeName}, {this.ItemTypeModel.GetGlobalCompilableTypeName()}>({context.OffsetVariableName});
+                var nativeArray = new NativeArray<{this.ItemTypeModel.GetGlobalCompilableTypeName()}>(bufferSpan.Length, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+                bufferSpan.CopyTo(nativeArray.AsSpan());
+                return nativeArray;
+            ";
+
+            return new CodeGeneratedMethod(body);
+        }
+        else
+        {
+            string body = $@"
+                if (!buffer.IsPinned)
+                    throw new NotSupportedException(""Non-greedy parsing of a NativeArray requires a pinned buffer."");
+                var bufferSpan = {context.InputBufferVariableName}.UnsafeReadSpan<{context.InputBufferTypeName}, {this.ItemTypeModel.GetGlobalCompilableTypeName()}>({context.OffsetVariableName});
+                var nativeArray = Unity.Collections.LowLevel.Unsafe.NativeArrayUnsafeUtilityEx.ConvertExistingDataToNativeArray<{this.ItemTypeModel.GetGlobalCompilableTypeName()}>(bufferSpan, Allocator.None);
+                #if ENABLE_UNITY_COLLECTIONS_CHECKS
+                Unity.Collections.LowLevel.Unsafe.NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle.GetTempUnsafePtrSliceHandle());
+                #endif
+                return nativeArray;
+            ";
+
+            return new CodeGeneratedMethod(body);
+        }
+    }
+
+    public override CodeGeneratedMethod CreateSerializeMethodBody(SerializationCodeGenContext context)
+    {
+        var writeNativeArray = $"{context.SpanWriterVariableName}.UnsafeWriteSpan({context.SpanVariableName}, {context.ValueVariableName}.AsSpan(), {context.OffsetVariableName}, " +
+                               $"{context.SerializationContextVariableName});";
+
+        return new CodeGeneratedMethod(writeNativeArray);
+    }
+
+    public override CodeGeneratedMethod CreateCloneMethodBody(CloneCodeGenContext context)
+    {
+        string parameters = $"{context.ItemVariableName}, Unity.Collections.Allocator.Persistent";
+        string body = $"return new Unity.Collections.NativeArray<{this.ItemTypeModel.GetCompilableTypeName()}>({parameters});";
+        return new CodeGeneratedMethod(body)
+        {
+            IsMethodInline = true,
+        };
+    }
+}

--- a/src/Tests/FlatSharpCompilerTests/CompilerTestHelpers.cs
+++ b/src/Tests/FlatSharpCompilerTests/CompilerTestHelpers.cs
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+using FlatSharp.TypeModel;
+
 namespace FlatSharpTests.Compiler;
 
 public static class CompilerTestHelpers
 {
     public static readonly FlatBufferSerializer CompilerTestSerializer = new FlatBufferSerializer(
-        new FlatBufferSerializerOptions { EnableAppDomainInterceptOnAssemblyLoad = true });
+        new FlatBufferSerializerOptions { EnableAppDomainInterceptOnAssemblyLoad = true }, TypeModelContainer.CreateDefault().WithUnitySupport(true));
 }

--- a/src/Tests/FlatSharpCompilerTests/FlatSharpCompilerTests.csproj
+++ b/src/Tests/FlatSharpCompilerTests/FlatSharpCompilerTests.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\FlatSharp.UnityPolyfills\FlatSharp.UnityPolyfills.csproj" />
     <ProjectReference Include="..\..\FlatSharp.Compiler\FlatSharp.Compiler.csproj" />
     <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
     <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" />

--- a/src/Tests/FlatSharpCompilerTests/FullTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/FullTests.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using Unity.Collections;
+
 namespace FlatSharpTests.Compiler;
 
 public class FullTests
@@ -76,6 +78,7 @@ public class FullTests
                 
             ScalarVector : [uint] ({MetadataKeys.VectorKind}:""IList"");
             ScalarArray : [uint] ({MetadataKeys.VectorKind}:""IReadOnlyList"");
+            ScalarUnityNativeArray : [uint] ({MetadataKeys.VectorKind}:""UnityNativeArray"");
 
             UnionVector : [Any] ({MetadataKeys.VectorKind}:""IList"");
             UnionArray : [Any] ({MetadataKeys.VectorKind}:""IReadOnlyList"");
@@ -98,7 +101,7 @@ public class FullTests
         }}
         ";
 
-        FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+        FlatSharpCompiler.CompileAndLoadAssembly(schema, new() { UnityAssemblyPath = typeof(NativeArray<>).Assembly.Location});
     }
 #endif
 }

--- a/src/Tests/FlatSharpCompilerTests/InvalidAttributeTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/InvalidAttributeTests.cs
@@ -126,6 +126,6 @@ public class InvalidAttributeTests
         ";
 
         var ex = Assert.Throws<InvalidFbsFileException>(() => FlatSharpCompiler.CompileAndLoadAssembly(schema, new()));
-        Assert.Contains("Unable to parse 'fs_vector' value 'banana'. Valid values are: IList, IReadOnlyList, Memory, ReadOnlyMemory, IIndexedVector.", ex.Message);
+        Assert.Contains("Unable to parse 'fs_vector' value 'banana'. Valid values are: IList, IReadOnlyList, Memory, ReadOnlyMemory, IIndexedVector, UnityNativeArray.", ex.Message);
     }
 }

--- a/src/Tests/FlatSharpPoolableEndToEndTests/FlatSharpPoolableEndToEndTests.csproj
+++ b/src/Tests/FlatSharpPoolableEndToEndTests/FlatSharpPoolableEndToEndTests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\..\FlatSharp.Compiler\FlatSharp.Compiler.csproj" Condition=" '$(PipelineBuild)' != 'true' " />
     <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
     <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" Condition=" '$(PipelineBuild)' != 'true' " />
+    <ProjectReference Include="..\..\FlatSharp.UnityPolyfills\FlatSharp.UnityPolyfills.csproj" />
     <ProjectReference Include="..\..\Google.FlatBuffers\Google.FlatBuffers.csproj" />
   </ItemGroup>
 

--- a/src/Tests/FlatSharpTests/ClassLib/TypeModelTests.cs
+++ b/src/Tests/FlatSharpTests/ClassLib/TypeModelTests.cs
@@ -17,6 +17,7 @@
 using System.Linq;
 using FlatSharp.CodeGen;
 using FlatSharp.TypeModel;
+using Unity.Collections;
 
 namespace FlatSharpTests;
 
@@ -1015,6 +1016,48 @@ public class TypeModelTests
 
         Assert.Equal(33, structModel.PhysicalLayout.Single().InlineSize);
         Assert.Equal(8, structModel.PhysicalLayout.Single().Alignment);
+    }
+    
+    [Fact]
+    public void TypeModel_Vector_NativeArrayOfUnionIsNotAllowed()
+    {
+        var ex = Assert.Throws<InvalidFlatBufferDefinitionException>(
+            () => TypeModelContainer.CreateDefault().WithUnitySupport(true).CreateTypeModel(typeof(NativeArray<FlatBufferUnion<string>>)));
+        Assert.Equal("UnityNativeArray vectors only support scalar or struct generic arguments. Type = Unity.Collections.NativeArray<FlatSharp.FlatBufferUnion<System.String>>.", ex.Message);
+    }
+    
+    [Fact]
+    public void TypeModel_Vector_NativeArrayOfClassIsNotAllowed()
+    {
+        var ex = Assert.Throws<InvalidFlatBufferDefinitionException>(
+            () => TypeModelContainer.CreateDefault().WithUnitySupport(true).CreateTypeModel(typeof(NativeArray<string>)));
+        Assert.Equal("UnityNativeArray vectors only support scalar or struct generic arguments. Type = Unity.Collections.NativeArray<System.String>.", ex.Message);
+    }
+    
+    [Fact]
+    public void Parse_NativeArrayThrowsExceptionForNonPinnedBuffer()
+    {
+        byte[] data =
+        {
+            12, 0, 0, 0, // offset to table start
+            6, 0,        // vtable length
+            8, 0,        // table length
+            4, 0,        // offset of index 0 field
+            0, 0,        // padding to 4-byte alignment
+            8, 0, 0, 0,  // soffset to vtable
+            4, 0, 0, 0,  // uoffset_t to vector
+            0, 0, 0, 0,  // vector length
+        };
+
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var table = new FlatBufferSerializer(
+                new FlatBufferSerializerOptions() { DeserializationOption = FlatBufferDeserializationOption.Lazy },
+                TypeModelContainer.CreateDefault().WithUnitySupport(true)).Parse<GenericTable<NativeArray<byte>>>(data);
+            
+            // the lazy access here should cause an exception
+            table.Value.GetHashCode();
+        });
     }
 
     public enum UntaggedEnum

--- a/src/Tests/FlatSharpTests/FlatSharpTests.csproj
+++ b/src/Tests/FlatSharpTests/FlatSharpTests.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\FlatSharp.UnityPolyfills\FlatSharp.UnityPolyfills.csproj" />
     <ProjectReference Include="..\..\FlatSharp.Runtime\FlatSharp.Runtime.csproj" />
     <ProjectReference Include="..\..\FlatSharp\FlatSharp.csproj" />
     <ProjectReference Include="..\..\Google.FlatBuffers\Google.FlatBuffers.csproj" />

--- a/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -296,6 +296,67 @@ public class VectorSerializationTests
         }
 
         [Fact]
+        public void UnalignedStruct_Value5Byte_NativeArray()
+        {
+            var root = new RootTable<NativeArray<ValueFiveByteStruct>>
+            {
+                Vector = new NativeArray<ValueFiveByteStruct>(new[]
+                {
+                    new ValueFiveByteStruct { Byte = 1, Int = 1 },
+                    new ValueFiveByteStruct { Byte = 2, Int = 2 },
+                    new ValueFiveByteStruct { Byte = 3, Int = 3 },
+                }, Allocator.Temp)
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                Span<byte> target = new byte[10240];
+                FlatBufferSerializer.DefaultWithUnitySupport.Serialize(root, target);
+            });
+        }
+
+        [Fact]
+        public void AlignedStruct_Value5Byte_NativeArray()
+        {
+            var root = new RootTable<NativeArray<ValueFiveByteStructWithPadding>>
+            {
+                Vector = new NativeArray<ValueFiveByteStructWithPadding>(new[]
+                {
+                    new ValueFiveByteStructWithPadding { Byte = 1, Int = 1 },
+                    new ValueFiveByteStructWithPadding { Byte = 2, Int = 2 },
+                    new ValueFiveByteStructWithPadding { Byte = 3, Int = 3 },
+                }, Allocator.Temp)
+            };
+
+            Span<byte> target = new byte[10240];
+            int offset = FlatBufferSerializer.DefaultWithUnitySupport.Serialize(root, target);
+            target = target.Slice(0, offset);
+
+            byte[] expectedResult =
+            {
+                4, 0, 0, 0,          // offset to table start
+                248, 255, 255, 255,  // soffset to vtable (-8)
+                12, 0, 0, 0,         // uoffset_t to vector
+                6, 0,                // vtable length
+                8, 0,                // table length
+                4, 0,                // offset of index 0 field
+                0, 0,                // padding to 4-byte alignment
+                3, 0, 0, 0,          // vector length
+                1, 0, 0, 0,          // index 0.Int
+                1,                   // index 0.Byte
+                0, 0, 0,             // padding
+                2, 0, 0, 0,          // index 1.Int
+                2,                   // index 1.Byte
+                0, 0, 0,             // padding
+                3, 0, 0, 0,          // index2.Int
+                3,                   // Index2.byte
+                0, 0, 0,             // padding
+            };
+
+            Assert.True(expectedResult.AsSpan().SequenceEqual(target));
+        }
+
+        [Fact]
         public void UnalignedStruct_9Byte()
         {
             var root = new RootTable2<IReadOnlyList<NineByteStruct>>
@@ -835,6 +896,14 @@ public class VectorSerializationTests
 
     [FlatBufferStruct, StructLayout(LayoutKind.Explicit, Size = 5)]
     public struct ValueFiveByteStruct
+    {
+        [FieldOffset(0)] public int Int;
+
+        [FieldOffset(4)] public byte Byte;
+    }
+
+    [FlatBufferStruct, StructLayout(LayoutKind.Explicit)]
+    public struct ValueFiveByteStructWithPadding
     {
         [FieldOffset(0)] public int Int;
 

--- a/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
+++ b/src/Tests/FlatSharpTests/SerializationTests/VectorSerializationTests.cs
@@ -18,6 +18,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using FlatSharp.TypeModel;
+using Unity.Collections;
 
 namespace FlatSharpTests;
 
@@ -111,8 +113,8 @@ public class VectorSerializationTests
                 };
 
                 Span<byte> target = new byte[1024];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                string csharp = FlatBufferSerializer.Default.Compile(root).GetCSharp();
+                int offset = FlatBufferSerializer.DefaultWithUnitySupport.Serialize(root, target);
+                string csharp = FlatBufferSerializer.DefaultWithUnitySupport.Compile(root).GetCSharp();
 
                 target = target.Slice(0, offset);
 
@@ -123,8 +125,10 @@ public class VectorSerializationTests
             Test<IReadOnlyList<byte>>(a => a.ToList());
             Test<Memory<byte>>(a => a.AsMemory());
             Test<ReadOnlyMemory<byte>>(a => a.AsMemory());
+            Test<NativeArray<byte>>(a => new NativeArray<byte>(a, Allocator.Temp));
             Test<Memory<byte>?>(a => a.AsMemory());
             Test<ReadOnlyMemory<byte>?>(a => a.AsMemory());
+            Test<NativeArray<byte>?>(a => new NativeArray<byte>(a, Allocator.Temp));
         }
 
         [Fact]
@@ -150,8 +154,8 @@ public class VectorSerializationTests
                 };
 
                 Span<byte> target = new byte[1024];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                string csharp = FlatBufferSerializer.Default.Compile(root).GetCSharp();
+                int offset = FlatBufferSerializer.DefaultWithUnitySupport.Serialize(root, target);
+                string csharp = FlatBufferSerializer.DefaultWithUnitySupport.Compile(root).GetCSharp();
 
                 target = target.Slice(0, offset);
 
@@ -162,8 +166,10 @@ public class VectorSerializationTests
             Test<IReadOnlyList<int>>(new List<int>());
             Test<Memory<byte>>(new Memory<byte>(new byte[0]));
             Test<ReadOnlyMemory<byte>>(new ReadOnlyMemory<byte>(new byte[0]));
+            Test<NativeArray<byte>>(new NativeArray<byte>(new byte[0], Allocator.Temp));
             Test<Memory<byte>?>(new Memory<byte>(new byte[0]));
             Test<ReadOnlyMemory<byte>?>(new ReadOnlyMemory<byte>(new byte[0]));
+            Test<NativeArray<byte>?>(new NativeArray<byte>(new byte[0], Allocator.Temp));
             Test<IIndexedVector<string, TableWithKey<string>>>(new IndexedVector<string, TableWithKey<string>>());
         }
 
@@ -186,8 +192,8 @@ public class VectorSerializationTests
                 };
 
                 Span<byte> target = new byte[1024];
-                int offset = FlatBufferSerializer.Default.Serialize(root, target);
-                string csharp = FlatBufferSerializer.Default.Compile(root).GetCSharp();
+                int offset = FlatBufferSerializer.DefaultWithUnitySupport.Serialize(root, target);
+                string csharp = FlatBufferSerializer.DefaultWithUnitySupport.Compile(root).GetCSharp();
 
                 target = target.Slice(0, offset);
 
@@ -198,6 +204,7 @@ public class VectorSerializationTests
             Test<IReadOnlyList<int>>();
             Test<Memory<byte>?>();
             Test<ReadOnlyMemory<byte>?>();
+            Test<NativeArray<byte>?>();
             Test<IIndexedVector<string, TableWithKey<string>>>();
 
             Test<IList<FlatBufferUnion<string>>>();


### PR DESCRIPTION
Implementation for issue https://github.com/jamescourtney/FlatSharp/issues/303

Initial work to support Unity's NativeArray as a supported vector type.

### Highlights:

- New C# project `FlatSharp.Compiler.UnityStub` (naming?) added to provide stub/polyfill APIs needed for schema compilation as well as test compilation.
- The C# file `src/FlatSharp.Compiler.UnityStub/UnityExtensions.cs` provides the glue to Unity APIs.
   - When built via the csproj (`FLATSHARP_UNITY_POLYFILLS` define) the `NativeArray` type is stubbed and extension methods for reading/writing are empty, allowing the usage of types and API surfaces but no functionality.
    - When this file is included in a Unity project, `NativeArray` is provided by Unity assemblies and the reading/writing methods are implemented against further Unity APIs.
- Note that `FlatSharp.Compiler.UnityStub` assembly will be deployed with the compiler, but should never be used at runtime in a Unity context

### Open Questions
1. I initially had the Unity APIs withing the FlatSharp.Compiler assembly itself. This worked until I started writing tests, as they APIs would either need to be public or the internals would need exposed to tests. Is the current "stub" assembly approach acceptable?
2. The `NativeArray` is constructed from the buffer/memory passed into `ReadNativeArrayBlock`. **A copy is not performed.** Is it safe to assume this memory is native or pinned managed memory that will not be moved?
3. I added test for simple usage of NativeArray which just validates the compiler generates proper code. I can add tests for actual functionality by further stubbing out Unity APIs. Any input on this?

Thanks!