### PR TITLE
RPC: allow null serviceImpl in BindService

### DIFF
--- a/src/FlatSharp.Compiler/SchemaModel/RpcServiceSchemaModel.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/RpcServiceSchemaModel.cs
@@ -208,7 +208,7 @@ public class RpcServiceSchemaModel : BaseSchemaModel
         }
 
         // Write bind service method
-        writer.AppendLine($"public static {GrpcCore}.ServerServiceDefinition BindService({baseClassName} serviceImpl)");
+        writer.AppendLine($"public static {GrpcCore}.ServerServiceDefinition BindService({baseClassName}? serviceImpl)");
         using (writer.WithBlock())
         {
             writer.AppendLine($"return {GrpcCore}.ServerServiceDefinition.CreateBuilder()");
@@ -216,7 +216,7 @@ public class RpcServiceSchemaModel : BaseSchemaModel
             {
                 foreach (var method in this.calls)
                 {
-                    writer.AppendLine($".AddMethod({methodNameMap[method.Name]}, serviceImpl.{method.Name})");
+                    writer.AppendLine($".AddMethod({methodNameMap[method.Name]}, serviceImpl == null ? null : serviceImpl.{method.Name})");
                 }
 
                 writer.AppendLine(".Build();");
@@ -225,13 +225,13 @@ public class RpcServiceSchemaModel : BaseSchemaModel
 
         // Write bind service overload
         writer.AppendLine();
-        writer.AppendLine($"public static void BindService({GrpcCore}.ServiceBinderBase serviceBinder, {baseClassName} serviceImpl)");
+        writer.AppendLine($"public static void BindService({GrpcCore}.ServiceBinderBase serviceBinder, {baseClassName}? serviceImpl)");
         using (writer.WithBlock())
         {
             foreach (var method in this.calls)
             {
                 string serverDelegate = GetServerHandlerDelegate(method);
-                writer.AppendLine($"serviceBinder.AddMethod({methodNameMap[method.Name]}, {serverDelegate});");
+                writer.AppendLine($"serviceBinder.AddMethod({methodNameMap[method.Name]}, serviceImpl == null ? null : {serverDelegate});");
             }
         }
     }

--- a/src/FlatSharp.Compiler/SchemaModel/RpcServiceSchemaModel.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/RpcServiceSchemaModel.cs
@@ -211,6 +211,7 @@ public class RpcServiceSchemaModel : BaseSchemaModel
         writer.AppendLine($"public static {GrpcCore}.ServerServiceDefinition BindService({baseClassName}? serviceImpl)");
         using (writer.WithBlock())
         {
+            writer.AppendLine("#pragma warning disable CS8604");
             writer.AppendLine($"return {GrpcCore}.ServerServiceDefinition.CreateBuilder()");
             using (writer.IncreaseIndent())
             {
@@ -221,6 +222,7 @@ public class RpcServiceSchemaModel : BaseSchemaModel
 
                 writer.AppendLine(".Build();");
             }
+            writer.AppendLine("#pragma warning restore CS8604");
         }
 
         // Write bind service overload
@@ -228,11 +230,13 @@ public class RpcServiceSchemaModel : BaseSchemaModel
         writer.AppendLine($"public static void BindService({GrpcCore}.ServiceBinderBase serviceBinder, {baseClassName}? serviceImpl)");
         using (writer.WithBlock())
         {
+            writer.AppendLine("#pragma warning disable CS8604");
             foreach (var method in this.calls)
             {
                 string serverDelegate = GetServerHandlerDelegate(method);
                 writer.AppendLine($"serviceBinder.AddMethod({methodNameMap[method.Name]}, serviceImpl == null ? null : {serverDelegate});");
             }
+            writer.AppendLine("#pragma warning restore CS8604");
         }
     }
 


### PR DESCRIPTION
For instance, using `MapGrpcService` from `Grpc.AspNetCore.Server` invokes this method with a `null` `serviceImpl`.