### PR TITLE
Add command line options as part of input hash

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharp.Compiler.csproj
+++ b/src/FlatSharp.Compiler/FlatSharp.Compiler.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Command line options changes now affect the input hash, which causes FlatSharp output to regenerate as expected.