### PR TITLE
Fix required properties

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             rid: win-x64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             rid: linux-x64
-          - os: macos-latest
+          - os: macos-12
             rid: osx-x64
     runs-on: ${{ matrix.os }}
     env:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,8 +18,8 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <Version>7.6.0</Version>
-    <PackageVersion>7.6.0</PackageVersion>
+    <Version>7.7.0</Version>
+    <PackageVersion>7.7.0</PackageVersion>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <Authors>James Courtney</Authors>
     <Description>FlatSharp is a fast, idiomatic implementation of the FlatBuffer binary format.</Description>

--- a/src/FlatSharp.Compiler/SetterKind.cs
+++ b/src/FlatSharp.Compiler/SetterKind.cs
@@ -52,12 +52,7 @@ public enum SetterKind
     ProtectedInternalInit = 5,
 
     /// <summary>
-    /// A private setter.
-    /// </summary>
-    Private = 6,
-
-    /// <summary>
     /// No setter.
     /// </summary>
-    None = 7,
+    None = 6,
 }

--- a/src/FlatSharp/FlatSharp.csproj
+++ b/src/FlatSharp/FlatSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>FlatSharp</AssemblyName>
     <RootNamespace>FlatSharp</RootNamespace>
     <Description>FlatSharp is an idiomatic C# implementation of the FlatBuffer serialization format. Use attributes to declare your data contracts!</Description>

--- a/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
+++ b/src/FlatSharp/Serialization/DeserializeClassDefinition.cs
@@ -45,7 +45,7 @@ internal class DeserializeClassDefinition
     protected readonly string vtableAccessor;
     protected readonly string remainingDepthAccessor;
 
-    private DeserializeClassDefinition(
+    public DeserializeClassDefinition(
         string className,
         MethodInfo? onDeserializeMethod,
         ITypeModel typeModel,
@@ -99,16 +99,6 @@ internal class DeserializeClassDefinition
                 this.instanceFieldDefinitions[VTableVariableName] = $"private {this.vtableTypeName} {VTableVariableName};";
             }
         }
-    }
-
-    public static DeserializeClassDefinition Create(
-        string className,
-        MethodInfo? onDeserializeMethod,
-        ITypeModel typeModel,
-        int maxVTableIndex,
-        FlatBufferSerializerOptions options)
-    {
-        return new DeserializeClassDefinition(className, onDeserializeMethod, typeModel, maxVTableIndex, options);
     }
 
     public bool HasEmbeddedBufferReference => !this.options.GreedyDeserialize;
@@ -222,8 +212,11 @@ internal class DeserializeClassDefinition
         }
 
         string required = string.Empty;
-        if (itemModel.IsRequired)
+
+        // Net 6.0 doesn't define this, so leave open the opportunity for users to add their own polyfills.
+        if (itemModel.PropertyInfo.GetCustomAttributes().Any(x => x.GetType().FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute"))
         {
+            FlatSharpInternal.Assert(itemModel.IsRequired, "Expecting the item to be required");
             required = " required";
         }
 

--- a/src/FlatSharp/TypeModel/TableTypeModel.cs
+++ b/src/FlatSharp/TypeModel/TableTypeModel.cs
@@ -669,7 +669,7 @@ $@"
 
         // We have to implement two items: The table class and the overall "read" method.
         // Let's start with the read method.
-        var classDef = DeserializeClassDefinition.Create(className, this.onDeserializeMethod, this, this.MaxIndex, context.Options);
+        var classDef = new DeserializeClassDefinition(className, this.onDeserializeMethod, this, this.MaxIndex, context.Options);
 
         // Build up a list of property overrides.
         foreach (var item in this.IndexToMemberMap.Where(x => !x.Value.IsDeprecated))

--- a/src/Tests/CompileTests/CSharp8/CSharp8.csproj
+++ b/src/Tests/CompileTests/CSharp8/CSharp8.csproj
@@ -23,6 +23,9 @@
     
     <!-- IsExternalInit not compatible with downstream languages. -->
     <FlatSharpSchema Remove="../../FlatSharpEndToEndTests/**/AccessModifiers.fbs" />
+
+    <!-- Required not compatible with C# 8. -->
+    <FlatSharpSchema Remove="../../FlatSharpEndToEndTests/**/Required.fbs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/FlatSharpEndToEndTests/Required/Required.cs
+++ b/src/Tests/FlatSharpEndToEndTests/Required/Required.cs
@@ -139,13 +139,15 @@ public class RequiredTests
     [DataRow(nameof(RequiredTable_Setters.None), false)]
     public void Only_Public_Setters_Are_CSharp_Required(string propertyName, bool expectRequired)
     {
-        // Make sure the property is flagged as being required.
         PropertyInfo property = typeof(RequiredTable_Setters).GetProperty(propertyName);
 
+#if NET7_0_OR_GREATER
+        // Make sure the property is flagged as being required.
         Assert.AreEqual(
             expectRequired,
             typeof(RequiredTable_Setters).GetProperty(propertyName).GetCustomAttributes().Any(x => x.GetType().FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute"));
-        
+#endif
+
         // Now make sure that FlatSharp still throws the error for required property missing even if the C# property is not required.
         RequiredTable_Setters table;
         if (propertyName == nameof(RequiredTable_Setters.None))
@@ -167,7 +169,9 @@ public class RequiredTests
 
 public partial class RequiredTable_Setters
 {
+#if NET7_0_OR_GREATER
     [SetsRequiredMembers]
+#endif
     public RequiredTable_Setters(bool setNone)
     {
         this.Pub = "a";

--- a/src/Tests/FlatSharpEndToEndTests/Required/Required.fbs
+++ b/src/Tests/FlatSharpEndToEndTests/Required/Required.fbs
@@ -1,6 +1,8 @@
 ﻿
 attribute "fs_serializer";
 attribute "fs_valueStruct";
+attribute "fs_setter";
+attribute "fs_defaultCtor";
 
 namespace FlatSharpEndToEndTests.Required;
 
@@ -24,6 +26,7 @@ table RequiredTable (fs_serializer)
     F : ValueStruct (required);
 }
 
+
 table NonRequiredTable (fs_serializer)
 {
     A : string;
@@ -32,4 +35,15 @@ table NonRequiredTable (fs_serializer)
     D : [ ubyte ];
     E : RefStruct;
     F : ValueStruct;
+}
+
+table RequiredTable_Setters (fs_serializer, fs_defaultCtor:"None")
+{
+    pub : string (required, fs_setter:"Public");
+    pub_init : string (required, fs_setter:"PublicInit");
+    prot : string (required, fs_setter:"Protected");
+    protected_internal : string (required, fs_setter:"ProtectedInternal");
+    protected_init : string (required, fs_setter:"ProtectedInit");
+    protected_internal_init : string (required, fs_setter:"ProtectedInternalInit");
+    none : string (required, fs_setter:"None");
 }


### PR DESCRIPTION
- Remove private setters, which were untested and did not work.
- Only flag `Public` and `PublicInit` setters with the `required` keyword. Setters with `None` + `Required` were broken with compilation errors previously.