### PR TITLE
chore: create output directory if not exists

### DIFF
--- a/src/FlatSharp.Compiler/FlatSharpCompiler.cs
+++ b/src/FlatSharp.Compiler/FlatSharpCompiler.cs
@@ -85,6 +85,12 @@ public class FlatSharpCompiler
             Console.Error.WriteLine("FlatSharp compiler: No output directory specified.");
             return -1;
         }
+        
+        // Create the output directory if it doesn't exist.
+        if (!Directory.Exists(options.OutputDirectory))
+        {
+            Directory.CreateDirectory(options.OutputDirectory);
+        }
 
         if (!string.IsNullOrEmpty(options.UnityAssemblyPath) && !File.Exists(options.UnityAssemblyPath))
         {


### PR DESCRIPTION
If the output directory doesn't exist, the compiler will return directly without any errors, which is a bit confusing. 
When the output directory does not exist, try to create it.