### PR TITLE
fix: emit attribute with escaped quote and backslash

### DIFF
--- a/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Text.RegularExpressions;
 using FlatSharp.Attributes;
 namespace FlatSharp.Compiler.SchemaModel;
 
@@ -61,7 +62,15 @@ public static class IFlatSharpAttributesExtensions
         foreach (var pair in attributes.RawAttributes)
         {
             string key = pair.Key;
-            string? value = pair.Value.Value?.Replace("\"", "\\\"");
+            string? value = pair.Value.Value;
+
+            // Append backslash to escape backslashes and quotes: 
+            // \ => \\
+            // " => \"
+            if (value is not null)
+            {
+                value = Regex.Replace(value!, "([\\\\\"])", "\\${1}");
+            }
 
             writer.AppendLine($"[FlatBufferMetadataAttribute(FlatBufferMetadataKind.FbsAttribute, \"{key}\", \"{value}\")]");
         }

--- a/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
@@ -61,7 +61,7 @@ public static class IFlatSharpAttributesExtensions
         foreach (var pair in attributes.RawAttributes)
         {
             string key = pair.Key;
-            string? value = pair.Value.Value;
+            string? value = pair.Value.Value?.Replace("\"", "\\\"");
 
             writer.AppendLine($"[FlatBufferMetadataAttribute(FlatBufferMetadataKind.FbsAttribute, \"{key}\", \"{value}\")]");
         }

--- a/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/IFlatSharpAttributes.cs
@@ -64,7 +64,7 @@ public static class IFlatSharpAttributesExtensions
             string key = pair.Key;
             string? value = pair.Value.Value;
 
-            // Append backslash to escape backslashes and quotes: 
+            // Prepend backslash to escape backslashes and quotes: 
             // \ => \\
             // " => \"
             if (value is not null)

--- a/src/Tests/FlatSharpCompilerTests/EscapedCharInAttributeTests.cs
+++ b/src/Tests/FlatSharpCompilerTests/EscapedCharInAttributeTests.cs
@@ -1,0 +1,44 @@
+﻿namespace FlatSharpTests
+{
+    public class EscapedCharInAttributeTests
+    {
+        [Fact]
+        public void EscapedCharInAttribute_DoubleQuote()
+        {
+            string schema = "namespace ns;attribute custom;table Foo { Bar : int (custom: \"hello,\\\"world\\\"\"); }";
+
+            var assembly = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            var foo = assembly.GetType("ns.Foo");
+            var bar = foo.GetProperty("Bar");
+            var metaAttr = bar.GetCustomAttribute<FlatBufferMetadataAttribute>();
+            Assert.NotNull(metaAttr.Value);
+            Assert.Equal("hello,\"world\"", metaAttr.Value.ToString());
+        }
+
+        [Fact]
+        public void EscapedCharInAttribute_SingleQuote()
+        {
+            string schema = "namespace ns;attribute custom;table Foo { Bar : int (custom: \"hello,'world'\"); }";
+
+            var assembly = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            var foo = assembly.GetType("ns.Foo");
+            var bar = foo.GetProperty("Bar");
+            var metaAttr = bar.GetCustomAttribute<FlatBufferMetadataAttribute>();
+            Assert.NotNull(metaAttr.Value);
+            Assert.Equal("hello,'world'", metaAttr.Value.ToString());
+        }
+
+        [Fact]
+        public void EscapedCharInAttribute_BackSlash()
+        {
+            string schema = "namespace ns;attribute custom;table Foo { Bar : int (custom: \"hello,\\\\world\"); }";
+
+            var assembly = FlatSharpCompiler.CompileAndLoadAssembly(schema, new());
+            var foo = assembly.GetType("ns.Foo");
+            var bar = foo.GetProperty("Bar");
+            var metaAttr = bar.GetCustomAttribute<FlatBufferMetadataAttribute>();
+            Assert.NotNull(metaAttr.Value);
+            Assert.Equal("hello,\\world", metaAttr.Value.ToString());
+        }
+    }
+}


### PR DESCRIPTION
The fbs below cannot be compiled because of unescaped double quotes.
```fbs
attribute custom_attribute;
namespace test;
table foo
{
    bar: int (custom_attribute: "hello, \"world\"");
}
```
This PR fixes it.