### PR TITLE
Struct equality

### DIFF
--- a/src/FlatSharp.Compiler/SchemaModel/ValueStructSchemaModel.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/ValueStructSchemaModel.cs
@@ -137,6 +137,10 @@ public class ValueStructSchemaModel : BaseSchemaModel
         this.Attributes.EmitAsMetadata(writer);
         writer.AppendLine($"[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit{size})]");
         writer.AppendLine($"public partial struct {this.Name}");
+        if (context.Options.GenerateMethods)
+        {
+            writer.AppendLine($": System.IEquatable<{this.Name}>");
+        }
         using (writer.WithBlock())
         {
             foreach (var field in this.fields)
@@ -151,6 +155,16 @@ public class ValueStructSchemaModel : BaseSchemaModel
 
             if (context.Options.GenerateMethods)
             {
+                string typeNames = string.Join(", ", this.fields.Select(x => x.TypeName));
+                string names = string.Join(", ", this.fields.Select(x => x.Name));
+                string tupleType = this.fields.Count == 0 ? "System.ValueTuple" : this.fields.Count == 1 ? $"System.ValueTuple<{typeNames}>" : $"({typeNames})";
+                string tupleValue = this.fields.Count < 2 ? $"System.ValueTuple.Create({names})" : $"({names})";
+                writer.AppendLine($"public {tupleType} ToTuple() => {tupleValue};");
+                writer.AppendLine($"public override bool Equals(object? obj) => obj is {this.Name} other && this.Equals(other);");
+                writer.AppendLine($"public bool Equals({this.Name} other) => ToTuple().Equals(other.ToTuple());");
+                writer.AppendLine($"public static bool operator ==({this.Name} left, {this.Name} right) => left.Equals(right);");
+                writer.AppendLine($"public static bool operator !=({this.Name} left, {this.Name} right) => !left.Equals(right);");
+                writer.AppendLine("public override int GetHashCode() => ToTuple().GetHashCode();");
                 // This matches C# records
                 string fieldStrings = string.Join(", ", this.fields.Select(x => $"{x.Name} = {{this.{x.Name}}}"));
                 string fieldStringsWithSpace = this.fields.Count == 0 ? " " : $" {fieldStrings} ";

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!-- MSTest early access packages. See: https://aka.ms/mstest/preview -->
     <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
@@ -15,4 +16,3 @@
     </packageSource>
   </packageSourceMapping>
 </configuration>
-

--- a/src/Tests/FlatSharpEndToEndTests/FlatSharpEndToEndTests.csproj
+++ b/src/Tests/FlatSharpEndToEndTests/FlatSharpEndToEndTests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <FlatSharpSchema Include="**\*.fbs" />
     <FlatSharpSchema Remove="ToStringMethods/ToStringMethods.fbs" />
+    <FlatSharpSchema Remove="StructEquality/StructEquality.fbs" />
   </ItemGroup>
 
   <Target Name="FlatSharpFbsCompileToString" BeforeTargets="ResolveAssemblyReferences">
@@ -67,7 +68,7 @@
     <PropertyGroup>
 	  <FlatSharpOutput>$(IntermediateOutputPath)</FlatSharpOutput>
       <FlatSharpOutput Condition=" '$(FlatSharpMutationTestingMode)' == 'true' ">$(MSBuildProjectDirectory)/</FlatSharpOutput>
-      <FlatSharpOutput>$(FlatSharpOutput)ToStringMethods</FlatSharpOutput>
+      <FlatSharpOutput>$(FlatSharpOutput)WithGenerateMethodsOption</FlatSharpOutput>
     </PropertyGroup>
 
 	<MakeDir Directories="$(FlatSharpOutput)" Condition="!Exists('$(FlatSharpOutput)')" />
@@ -76,7 +77,7 @@
     <PropertyGroup>
       <CompilerPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\tools\$(CompilerVersion)\FlatSharp.Compiler.dll'))</CompilerPath>
       <CompilerPath Condition=" '$(FlatSharpCompilerPath)' != '' ">$(FlatSharpCompilerPath)</CompilerPath>
-      <CompilerCommand>dotnet &quot;$(CompilerPath)&quot; --input &quot;ToStringMethods/ToStringMethods.fbs&quot; --output &quot;$(FlatSharpOutput)&quot; --generate-methods</CompilerCommand>
+      <CompilerCommand>dotnet &quot;$(CompilerPath)&quot; --input &quot;ToStringMethods/ToStringMethods.fbs;StructEquality/StructEquality.fbs&quot; --output &quot;$(FlatSharpOutput)&quot; --generate-methods</CompilerCommand>
     </PropertyGroup>
 
     <Message Text="$(CompilerCommand)" Importance="high" />

--- a/src/Tests/FlatSharpEndToEndTests/StructEquality/StructEquality.cs
+++ b/src/Tests/FlatSharpEndToEndTests/StructEquality/StructEquality.cs
@@ -1,0 +1,77 @@
+﻿using FlatSharpEndToEndTests.Unions;
+
+namespace FlatSharpEndToEndTests.StructEquality;
+
+[TestClass]
+public class StructEqualityTests
+{
+    [TestMethod]
+    public void ToTupleMethod()
+    {
+        MixedValueStruct mixedValueStruct = new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 };
+
+        var expectedValueStructTuple = (1, 2f, (ushort)5);
+
+        Assert.AreEqual(expectedValueStructTuple, mixedValueStruct.ToTuple());
+    }
+
+    [TestMethod]
+    public void EqualsMethod()
+    {
+        MixedValueStruct mixedValueStruct = new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 };
+        StructUnion structUnion = new StructUnion(new A { V = 1 });
+
+        var mismatchedStruct = new MixedValueStruct { X = 20 };
+        var mismatchedUnion = new StructUnion(new B { V = 1 });
+        var mismatchedObject = "hi";
+
+        Assert.IsTrue(mixedValueStruct.Equals(new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 }));
+        Assert.IsFalse(mixedValueStruct.Equals(mismatchedStruct));
+        Assert.IsFalse(mixedValueStruct.Equals(mismatchedObject));
+        Assert.IsTrue(structUnion.Equals(new StructUnion(new A { V = 1 })));
+        Assert.IsFalse(structUnion.Equals(mismatchedUnion));
+        Assert.IsFalse(mixedValueStruct.Equals(mismatchedObject));
+    }
+
+    [TestMethod]
+    public void EqualityOperator()
+    {
+        MixedValueStruct mixedValueStruct = new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 };
+        StructUnion structUnion = new StructUnion(new A { V = 1 });
+
+        var mismatchedStruct = new MixedValueStruct { X = 10 };
+        var mismatchedUnion = new StructUnion(new B { V = 21 });
+
+        Assert.IsTrue(mixedValueStruct == new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 });
+        Assert.IsFalse(mixedValueStruct == mismatchedStruct);
+        Assert.IsTrue(structUnion == new StructUnion(new A { V = 1 }));
+        Assert.IsFalse(structUnion == mismatchedUnion);
+    }
+
+    [TestMethod]
+    public void InequalityOperator()
+    {
+        MixedValueStruct mixedValueStruct = new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 };
+        StructUnion structUnion = new StructUnion(new A { V = 1 });
+
+        var mismatchedStruct = new MixedValueStruct { Y = 13f };
+        var mismatchedUnion = new StructUnion(new C { V = 42 });
+        var mirrorStruct = mixedValueStruct;
+        var mirrorUnion = structUnion;
+
+        Assert.IsTrue(mixedValueStruct != mismatchedStruct);
+        Assert.IsFalse(mixedValueStruct != mirrorStruct);
+        Assert.IsTrue(structUnion != mismatchedUnion);
+        Assert.IsFalse(structUnion != mirrorUnion);
+    }
+
+    [TestMethod]
+    public void GetHashCodeMethod()
+    {
+        MixedValueStruct mixedValueStruct = new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 };
+        StructUnion structUnion = new StructUnion(new A { V = 1 });
+
+        Assert.AreEqual(new MixedValueStruct { X = 1, Y = 2f, Z = (ushort)5 }.GetHashCode(), mixedValueStruct.GetHashCode());
+        Assert.AreEqual(new StructUnion(new A { V = 1 }).GetHashCode(), structUnion.GetHashCode());
+    }
+}

--- a/src/Tests/FlatSharpEndToEndTests/StructEquality/StructEquality.fbs
+++ b/src/Tests/FlatSharpEndToEndTests/StructEquality/StructEquality.fbs
@@ -1,0 +1,12 @@
+attribute "fs_valueStruct";
+
+namespace FlatSharpEndToEndTests.StructEquality;
+
+struct MixedValueStruct (fs_valueStruct) { X : int; Y : float; Z : ushort; }
+
+struct A (fs_valueStruct) { V : uint; }
+struct B (fs_valueStruct) { V : uint; }
+struct C (fs_valueStruct) { V : uint; }
+struct D (fs_valueStruct) { V : uint; }
+
+union StructUnion { A, B, C, D }


### PR DESCRIPTION
This adds `Equals()`, and `GetHashCode()` methods and `==/!=` operators for value structs and value unions. They can be enabled with the `--generate-methods` flag. 

These methods fix the analyzer warning:
`CA1815: Override equals and operator equals on value types`