### PR TITLE
Change workflow to trigger on PR on any branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,8 @@ name: .NET
 
 on:
   push:
-    branches: [ main, upstream ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, upstream ]
   workflow_dispatch:
 
 jobs:  


### PR DESCRIPTION
Actions will trigger on push to main and on PR to any branch.

As an example, I have a branch named upstream in my fork which mirrors this repo's main, and I would like to be able to open a PR against it as a test before submitting a PR here.