### PR TITLE
Emit attributes for union values 

### DIFF
--- a/src/FlatSharp.Compiler/SchemaModel/ValueUnionSchemaModel.cs
+++ b/src/FlatSharp.Compiler/SchemaModel/ValueUnionSchemaModel.cs
@@ -192,9 +192,11 @@ public class ValueUnionSchemaModel : BaseSchemaModel
                 this.WriteUncheckedGetItemMethod(writer, index, item.resolvedType, item.value, propertyClrType, generateUnsafeItems);
 
                 writer.AppendLine();
+                new FlatSharpAttributes(item.value.Attributes).EmitAsMetadata(writer);
                 writer.AppendLine($"public {item.resolvedType} {item.value.Key} => this.Item{index};");
 
                 writer.AppendLine();
+                new FlatSharpAttributes(item.value.Attributes).EmitAsMetadata(writer);
                 writer.AppendLine($"public {item.resolvedType} Item{index}");
                 using (writer.WithBlock())
                 {

--- a/src/Tests/FlatSharpEndToEndTests/MetadataAttributes/MetadataAttributeTests.cs
+++ b/src/Tests/FlatSharpEndToEndTests/MetadataAttributes/MetadataAttributeTests.cs
@@ -43,6 +43,10 @@ public class MetadataAttributesTestCases
         var attrs = GetAttributes<MyUnion>();
         Assert.AreEqual(1, attrs.Count);
         Assert.AreEqual("MyUnion", attrs["test"]);
+
+        attrs = GetAttributes(typeof(MyUnion).GetProperty("A"));
+        Assert.AreEqual(1, attrs.Count);
+        Assert.AreEqual("A", attrs["test"]);
     }
 
     [TestMethod]

--- a/src/Tests/FlatSharpEndToEndTests/MetadataAttributes/MetadataAttributes.fbs
+++ b/src/Tests/FlatSharpEndToEndTests/MetadataAttributes/MetadataAttributes.fbs
@@ -26,7 +26,11 @@ struct RefStruct (test:"RefStruct")
     i : int (test:"i");
 }
 
-union MyUnion (test:"MyUnion") { ValueStruct }
+union MyUnion (test:"MyUnion")
+{
+    A : ValueStruct (test:"A"),
+    B : RefStruct
+}
 
 table Message (fs_serializer:"Lazy", test:"Message") {
     value : string (required, fs_sharedString, test:"value");


### PR DESCRIPTION
This is similar to what is currently done for tables. It is useful for doing reflection.