### PR TITLE
Update macos runner

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
             rid: win-x64
           - os: ubuntu-22.04
             rid: linux-x64
-          - os: macos-12
+          - os: macos-13
             rid: osx-x64
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Previous version macos-12 no longer exists.
macos-12 -> macos-13
Reason for not using macos-14 with osx-arm64 is that grpc-tools are not available.
More info: https://github.com/grpc/grpc/issues/25755